### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 9.0.100
+      - run: dotnet restore
+      - run: dotnet build --no-restore -c Release
+      - run: dotnet test --no-build -c Release
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Lint code, HTML and Markdown
+        uses: super-linter/super-linter@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VALIDATE_CSHARP: true
+          VALIDATE_HTML: true
+          VALIDATE_MARKDOWN: true
+          DEFAULT_BRANCH: master
+          VALIDATE_ALL_CODEBASE: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+# Repository Guidance
+
+- This repository uses GitHub Actions to automate testing and linting.
+- Workflows are located in `.github/workflows`.
+- When adding or modifying workflows, please update this file to document the changes.
+- Continuous integration runs tests with `dotnet` and checks code style using Super-Linter for C#, HTML and Markdown files.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow `ci.yml` that restores, builds and tests
- lint C# code, HTML, and Markdown via super-linter
- document workflows in `AGENTS.md`

## Testing
- `dotnet build Olve.Utilities.sln --verbosity minimal`
- `dotnet test Olve.Utilities.sln --no-build --verbosity minimal` *(failed: 1 test failed)*

------
https://chatgpt.com/codex/tasks/task_e_686906e21f448324b948764c58251d96