### PR TITLE
Add CodeDog AI review workflow

### DIFF
--- a/.github/workflows/codedog-review.yml
+++ b/.github/workflows/codedog-review.yml
@@ -1,0 +1,18 @@
+name: CodeDog Review
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  codedog:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: codedog-ai/codedog-action@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          config-path: codedog.yml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+# Repository Agent Guidelines
+
+- Run `dotnet test` before committing changes.
+- Use Conventional Commits for commit messages.
+- Update this file whenever automation or tooling changes.
+
+## Current Automation
+- `codedog-review.yml` performs AI-powered pull request reviews using CodeDog and OpenAI.

--- a/README.md
+++ b/README.md
@@ -5,3 +5,16 @@
 The purpose of this library is to provide a set of utilities that can be used in .NET projects.
 
 Please read the [documentation](https://olivervea.github.io/Olve.Utilities/) for more information.
+## CodeDog AI Reviews
+
+This repository runs [CodeDog](https://github.com/codedog-ai/codedog) on every pull request to provide AI-powered code review suggestions.
+Add an `OPENAI_API_KEY` secret in the repository settings to enable the OpenAI backend.
+CodeDog will comment with a summary of issues and improvement tips after each PR is opened.
+
+Example output:
+
+```
+### CodeDog Review Summary
+- Potential bug in `MyClass.cs` line 42
+- Style improvements suggested for `helpers.ts`
+```

--- a/codedog.yml
+++ b/codedog.yml
@@ -1,0 +1,14 @@
+provider: openai
+openai:
+  model: gpt-4o
+  temperature: 0.2
+review:
+  paths:
+    include:
+      - "src/**/*.cs"
+      - "src/**/*.ts"
+    exclude:
+      - "**/*.md"
+  prompt: >
+    You are a diligent code reviewer. Highlight bugs, suggest style improvements,
+    and note missing tests.


### PR DESCRIPTION
## Summary
- add CodeDog GitHub Action workflow
- configure CodeDog with OpenAI model
- update README with setup instructions and example output
- document repository automation in AGENTS.md

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869334b8b2c8324b139336338fe6e55