### PR TITLE
Update project READMEs with usage improvements

### DIFF
--- a/src/Olve.Operations/README.md
+++ b/src/Olve.Operations/README.md
@@ -1,1 +1,37 @@
 # Olve.Operations
+[![NuGet](https://img.shields.io/nuget/v/Olve.Operations?logo=nuget)](https://www.nuget.org/packages/Olve.Operations)
+
+Abstractions for implementing operations that return `Result` objects. Provides factories
+for creating operations through dependency injection.
+
+## Installation
+
+```bash
+dotnet add package Olve.Operations
+```
+
+## Usage
+
+```csharp
+public class BuyItemOperation : IAsyncOperation<BuyItemOperation.Request>
+{
+    public record Request(string SkuId, int Quantity, float Price);
+
+    public async ValueTask<Result> ExecuteAsync(Request request, CancellationToken ct = default)
+    {
+        // perform work
+        return Result.Success();
+    }
+}
+
+var op = new BuyItemOperation();
+var result = await op.ExecuteAsync(new BuyItemOperation.Request("ABC123", 2, 9.99f));
+if (result.Succeeded)
+{
+    // handle success
+}
+```
+
+`IOperation<TRequest>` is available for synchronous implementations.
+
+See the [API documentation](https://olivervea.github.io/Olve.Utilities/api/) for more details.

--- a/src/Olve.Paths.Glob/README.md
+++ b/src/Olve.Paths.Glob/README.md
@@ -24,3 +24,5 @@ var path = Path.Create("/home/user/documents");
 var glob = path.Glob("*.txt"); // Matches all .txt files in the directory
 var allFiles = path.Glob("**/*"); // Matches all files in the directory and subdirectories
 ```
+
+See the [API documentation](https://olivervea.github.io/Olve.Utilities/api/) for more details.

--- a/src/Olve.Paths/README.md
+++ b/src/Olve.Paths/README.md
@@ -34,3 +34,5 @@ var folderName = path.Name; // documents
 var newPath = path / "newfile.txt"; // /home/user/documents/newfile.txt
 var exists = newPath.Exists(); // Check if the file exists
 ```
+
+See the [API documentation](https://olivervea.github.io/Olve.Utilities/api/) for more details.

--- a/src/Olve.Results.TUnit/README.md
+++ b/src/Olve.Results.TUnit/README.md
@@ -1,3 +1,21 @@
 # Olve.Results.TUnit
+[![NuGet](https://img.shields.io/nuget/v/Olve.Results.TUnit?logo=nuget)](https://www.nuget.org/packages/Olve.Results.TUnit)
 
-Will be filled out
+TUnit assertion extensions for verifying `Result` values in unit tests.
+
+## Installation
+
+```bash
+dotnet add package Olve.Results.TUnit
+```
+
+## Usage
+
+```csharp
+await Assert.That(myResult).Succeeded();
+await Assert.That(myResult).SucceededAndValue().IsNotNull();
+await Assert.That(myResult).Failed();
+await Assert.That(myResult).FailedAndProblemCollection().IsNotEmpty();
+```
+
+See the [API documentation](https://olivervea.github.io/Olve.Utilities/api/) for more details.

--- a/src/Olve.Results/README.md
+++ b/src/Olve.Results/README.md
@@ -1,1 +1,37 @@
 # Olve.Results
+[![NuGet](https://img.shields.io/nuget/v/Olve.Results?logo=nuget)](https://www.nuget.org/packages/Olve.Results)
+
+Lightweight result type used for error handling throughout the repository. It represents success or a collection of problems instead of throwing exceptions.
+
+## Installation
+
+```bash
+dotnet add package Olve.Results
+```
+
+## Usage
+
+```csharp
+Result<string> result = Result.Try(() => File.ReadAllText("/tmp/test.txt"));
+if (result.TryPickProblems(out var problems, out var text))
+{
+    foreach (var p in problems)
+        Console.WriteLine(p.Message);
+    return;
+}
+
+Console.WriteLine(text);
+
+// chain multiple steps
+Result<(GL, IInputContext)> contexts = Result.Concat(
+    () => Result.Try(() => window.CreateOpenGL(), "create GL"),
+    () => Result.Try(() => window.CreateInput(), "create input"));
+
+// aggregate results
+foreach (var service in services)
+    loadResults.Add(service.Load());
+if (loadResults.TryPickProblems(out var loadProblems))
+    return loadProblems.Prepend("scene load failed");
+```
+
+See the [API documentation](https://olivervea.github.io/Olve.Utilities/api/) for more details.

--- a/src/Olve.Utilities/README.md
+++ b/src/Olve.Utilities/README.md
@@ -1,0 +1,20 @@
+# Olve.Utilities
+[![NuGet](https://img.shields.io/nuget/v/Olve.Utilities?logo=nuget)](https://www.nuget.org/packages/Olve.Utilities)
+
+Miscellaneous helpers such as collection extensions, ID generators and startup utilities.
+
+## Installation
+
+```bash
+dotnet add package Olve.Utilities
+```
+
+## Usage
+
+```csharp
+var generator = new ThreadSafeUintGenerator();
+var id = generator.Next();
+Console.WriteLine(id);
+```
+
+See the [documentation](https://olivervea.github.io/Olve.Utilities/) for more details.

--- a/src/source-generators/Olve.SG.CopyProperties/README.md
+++ b/src/source-generators/Olve.SG.CopyProperties/README.md
@@ -1,0 +1,19 @@
+# Olve.SG.CopyProperties
+[![NuGet](https://img.shields.io/nuget/v/Olve.SG.CopyProperties?logo=nuget)](https://www.nuget.org/packages/Olve.SG.CopyProperties)
+
+Source generator that copies properties from a source type to a target declaration using a `[CopyProperties]` attribute.
+
+## Installation
+
+```bash
+dotnet add package Olve.SG.CopyProperties
+```
+
+## Usage
+
+```csharp
+[CopyProperties(typeof(Source))]
+public partial class Target { }
+```
+
+See the [API documentation](https://olivervea.github.io/Olve.Utilities/api/) for more details.


### PR DESCRIPTION
## Summary
- expand usage snippets for Olve.Operations with async example
- show more TUnit assertion helpers
- demonstrate chaining and aggregation for Olve.Results

## Testing
- `dotnet test --no-build --verbosity normal`


------
https://chatgpt.com/codex/tasks/task_e_687e147a7c448324862d360d4019aed3