### PR TITLE
Fix analyzer version mismatch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,4 +2,7 @@
 
 - Central package versions are defined in `Directory.Packages.props`.
 - Projects using builders reference the `BuilderGenerator` package. Version `3.1.0` is listed centrally.
+- `Microsoft.CodeAnalysis.CSharp` uses version `4.13.0` to match the SDK.
+- Analyzer packages (`Microsoft.CodeAnalysis.*Analyzers`) use version `4.14.0`.
+- The compiler version is locked by `Microsoft.Net.Compilers.Toolset` `4.13.0`.
 - Keep this file updated as packages or build tooling change.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,8 +2,9 @@
   <ItemGroup>
     <PackageVersion Include="Meziantou.Analyzer" Version="2.0.201" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="4.14.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="4.12.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="4.14.0" />
+    <PackageVersion Include="Microsoft.Net.Compilers.Toolset" Version="4.13.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.5" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.5" />
     <PackageVersion Include="Microsoft.Extensions.FileSystemGlobbing"  Version="9.0.5" />

--- a/tests/Olve.Utilities.Tests/Projects/ProjectFolderHelperTests.cs
+++ b/tests/Olve.Utilities.Tests/Projects/ProjectFolderHelperTests.cs
@@ -19,15 +19,9 @@ public class ProjectFolderHelperTests
         // Assert
         if (Environment.OSVersion.Platform == PlatformID.Unix)
         {
-            await Assert.That(rootFolder).StartsWith("/home/");
-            var elements = rootFolder.Split("/").Where(x => !string.IsNullOrWhiteSpace(x)).ToArray();
-            await Assert.That(elements.Length).IsEqualTo(6);
-            await Assert.That(elements[0]).IsEqualTo("home");
-            await Assert.That(elements[1]).IsEqualTo(Environment.UserName);
-            await Assert.That(elements[2]).IsEqualTo(".local");
-            await Assert.That(elements[3]).IsEqualTo("share");
-            await Assert.That(elements[4]).IsEqualTo(organization);
-            await Assert.That(elements[5]).IsEqualTo(projectName);
+            var userHome = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            var expected = System.IO.Path.Combine(userHome, ".local", "share", organization, projectName);
+            await Assert.That(rootFolder).IsEqualTo(expected);
         }
     }
 }


### PR DESCRIPTION
## Summary
- update Roslyn versions to align with .NET SDK
- relax ProjectFolderHelperTests path assertion

## Testing
- `dotnet build Olve.Utilities.sln --no-restore --verbosity minimal`
- `dotnet test --no-build --verbosity minimal --logger "trx"`

------
https://chatgpt.com/codex/tasks/task_e_687e1ce052448324a866d8894f9bde95