### PR TITLE
feat: publish project readme files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@
 - `Microsoft.CodeAnalysis.CSharp` uses version `4.13.0` to match the SDK.
 - Analyzer packages (`Microsoft.CodeAnalysis.*Analyzers`) use version `4.14.0`.
 - The compiler version is locked by `Microsoft.Net.Compilers.Toolset` `4.13.0`.
+- README files from `src/**/README.md` are included in the documentation via DocFX `build.content`.
 - Keep this file updated as packages or build tooling change.
 - To run tests: `dotnet test --verbosity normal --logger "console;verbosity=minimal"`
 

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -45,6 +45,12 @@
         "exclude": [
           "_site/**"
         ]
+      },
+      {
+        "src": "../",
+        "files": [
+          "src/**/README.md"
+        ]
       }
     ],
     "resource": [


### PR DESCRIPTION
## Summary
- add README files from `src` to docfx content
- document README inclusion in AGENTS guidelines

## Testing
- `dotnet docfx docs/docfx.json --logLevel Warning`
- `dotnet test --verbosity normal --logger "console;verbosity=minimal"`

------
https://chatgpt.com/codex/tasks/task_e_687e246d1dbc8324a011dfd6d05f911a