### PR TITLE
Expose source generators transitively

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 - The compiler version is locked by `Microsoft.Net.Compilers.Toolset` `4.13.0`.
 - README files from `src/**/README.md` are included in the documentation via DocFX `build.content`.
 - `Olve.Results.Validation` is part of the DocFX metadata `src` list. Add new projects there when needed.
-- `Olve.Validation.SourceGenerators` contains a Roslyn generator used by `Olve.Validation.SourceGeneration`.
+- `Olve.Validation.SourceGeneration` includes `Olve.Validation.SourceGenerators` as a transitive analyzer so consumers get the generator automatically.
 - Run `dotnet docfx metadata docs/docfx.json` when source projects change to keep YAML up to date.
 - Keep this file updated as packages or build tooling change.
 - To run tests: `dotnet test --verbosity normal --logger "console;verbosity=minimal"`

--- a/src/Olve.Validation.SourceGeneration/Olve.Validation.SourceGeneration.csproj
+++ b/src/Olve.Validation.SourceGeneration/Olve.Validation.SourceGeneration.csproj
@@ -1,12 +1,27 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <Title>Olve.Validation.SourceGeneration</Title>
+    <Authors>Oliver Vea</Authors>
+    <Description>Utilities that expose Olve.Validation.SourceGenerators transitively.</Description>
+    <Copyright>Oliver Vea</Copyright>
+    <PackageProjectUrl>https://github.com/OliverVea/Olve.Utilities/src/Olve.Validation.SourceGeneration</PackageProjectUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <RepositoryUrl>https://github.com/OliverVea/Olve.Utilities</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+    <IsTrimmable>true</IsTrimmable>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TargetFramework>net9.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
-    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Olve.Validation\Olve.Validation.csproj" />
-    <ProjectReference Include="..\Olve.Validation.SourceGenerators\Olve.Validation.SourceGenerators.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer" />
+    <ProjectReference Include="..\Olve.Validation.SourceGenerators\Olve.Validation.SourceGenerators.csproj"
+                      ReferenceOutputAssembly="false"
+                      OutputItemType="Analyzer"
+                      PrivateAssets="all"
+                      IncludeAssets="analyzers;build;buildtransitive" />
   </ItemGroup>
 </Project>

--- a/src/Olve.Validation.SourceGeneration/ValidatorForAttribute.cs
+++ b/src/Olve.Validation.SourceGeneration/ValidatorForAttribute.cs
@@ -1,9 +1,19 @@
 namespace Olve.Validation.SourceGeneration;
 
+/// <summary>
+/// Attribute applied to validators to indicate the target type.
+/// </summary>
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
 public sealed class ValidatorForAttribute : Attribute
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ValidatorForAttribute"/> class.
+    /// </summary>
+    /// <param name="targetType">Type that the validator handles.</param>
     public ValidatorForAttribute(Type targetType) => TargetType = targetType;
 
+    /// <summary>
+    /// Gets the type that the validator targets.
+    /// </summary>
     public Type TargetType { get; }
 }


### PR DESCRIPTION
## Summary
- publish Olve.Validation.SourceGeneration as a package
- include Olve.Validation.SourceGenerators as a transitive analyzer
- document analyzer behavior in AGENTS
- add missing XML docs to ValidatorForAttribute

## Testing
- `dotnet docfx metadata docs/docfx.json`
- `dotnet test --no-build --verbosity normal --logger "console;verbosity=minimal"` *(fails: GeneratedConfigure_WiresValidators)*

------
https://chatgpt.com/codex/tasks/task_e_68846be8af9c8324a7012899e690fc3c