### PR TITLE
Add step to sync version bumps to develop

### DIFF
--- a/.github/workflows/push_master.yml
+++ b/.github/workflows/push_master.yml
@@ -94,6 +94,20 @@ jobs:
         if: "${{ steps.version-changed.outputs.changed == 'true' }}"
         run: echo "::notice::id=${{ steps.release.outputs.id }}"
 
+  push-to-develop:
+    name: Copy bump commit to develop
+    needs:
+      - bump-version
+    if: "${{ needs.bump-version.outputs.changed == 'true' }}"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Push to develop
+        run: git push origin HEAD:develop
+
   publish-packages:
     name: Publish NuGet Packages in Parallel
     needs:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@
 - `Olve.Validation.SourceGeneration` includes `Olve.Validation.SourceGenerators` as a transitive analyzer so consumers get the generator automatically.
 - Run `dotnet docfx metadata docs/docfx.json` when source projects change to keep YAML up to date.
 - Keep this file updated as packages or build tooling change.
+- Version bump commits on `master` are automatically pushed to `develop` via the workflow.
 - To run tests: `dotnet test --verbosity normal --logger "console;verbosity=minimal"`
 
 ## Examples of XML Documentation in Source Code


### PR DESCRIPTION
## Summary
- push version bumps from `master` to `develop`
- document auto-sync behaviour

## Testing
- `dotnet test --verbosity normal --logger "console;verbosity=minimal"` *(fails: GeneratedConfigure_WiresValidators test)*

------
https://chatgpt.com/codex/tasks/task_e_6884766e7ea08324bab1da4e5caf6371