### PR TITLE
Add doc for ValidatorForGenerator

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@
 - The compiler version is locked by `Microsoft.Net.Compilers.Toolset` `4.13.0`.
 - README files from `src/**/README.md` are included in the documentation via DocFX `build.content`.
 - `Olve.Results.Validation` is part of the DocFX metadata `src` list. Add new projects there when needed.
+- `Olve.Validation.SourceGeneration` is documented via DocFX to cover the generator.
 - `Olve.Validation.SourceGeneration` includes `Olve.Validation.SourceGenerators` as a transitive analyzer so consumers get the generator automatically.
 - Run `dotnet docfx metadata docs/docfx.json` when source projects change to keep YAML up to date.
 - Keep this file updated as packages or build tooling change.

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -29,6 +29,12 @@
           ]
         },
         {
+          "src": "../src/Olve.Validation.SourceGeneration",
+          "files": [
+            "**/Olve.Validation.SourceGeneration.csproj"
+          ]
+        },
+        {
           "src": "../src/Olve.Operations",
           "files": [
             "**/Olve.Operations.csproj"

--- a/src/Olve.Validation.SourceGeneration/README.md
+++ b/src/Olve.Validation.SourceGeneration/README.md
@@ -1,0 +1,17 @@
+# Olve.Validation.SourceGeneration
+
+`ValidatorForGenerator` wires property validators into partial validator classes.
+
+Apply `[ValidatorFor(typeof(T))]` to a partial class and add static methods named
+`Get<PropertyName>Validator` returning `IValidator<PropertyType>`. The generator
+produces a class deriving from `ValidatorFor<T>` that maps each property to its
+validator.
+
+```csharp
+[ValidatorFor(typeof(MyDto))]
+public partial class MyDtoValidator
+{
+    private static IValidator<string> GetNameValidator() => new StringValidator();
+    private static IValidator<int> GetAgeValidator() => new IntValidator();
+}
+```


### PR DESCRIPTION
## Summary
- document ValidatorForGenerator usage
- include generator project in DocFX metadata
- note generator documentation in AGENTS

## Testing
- `dotnet docfx metadata docs/docfx.json`

------
https://chatgpt.com/codex/tasks/task_e_68847f2fbac083249f7d04e40e10bc7b