### PR TITLE
fix: validate default struct values

### DIFF
--- a/src/Olve.Validation/BaseStructValidator.cs
+++ b/src/Olve.Validation/BaseStructValidator.cs
@@ -15,6 +15,6 @@ public abstract class BaseStructValidator<TValue, TValidator> : BaseValidator<TV
     /// Fails validation if the value is the default for its type.
     /// </summary>
     protected TValidator IsNotDefault() => FailIf(
-        value => !value.Equals(default(TValue)),
+        value => value.Equals(default(TValue)),
         _ => new ResultProblem("Value was default"));
 }

--- a/tests/Olve.Validation.SourceGeneration.Tests/ValidatorForGeneratorTests.cs
+++ b/tests/Olve.Validation.SourceGeneration.Tests/ValidatorForGeneratorTests.cs
@@ -11,7 +11,8 @@ public class MyDto
 [ValidatorFor(typeof(MyDto))]
 public partial class MyDtoValidator
 {
-    private static IValidator<string> GetNameValidator() => new StringValidator();
+    private static IValidator<string> GetNameValidator() => new StringValidator()
+        .IsNotNullOrWhiteSpace();
     
     private static IValidator<int> GetAgeValidator() => new IntValidator()
         .IsPositive()

--- a/tests/Olve.Validation.Tests/BaseStructValidatorTests.cs
+++ b/tests/Olve.Validation.Tests/BaseStructValidatorTests.cs
@@ -1,0 +1,27 @@
+using Olve.Results;
+using Olve.Results.TUnit;
+
+namespace Olve.Validation.Tests;
+
+public class BaseStructValidatorTests
+{
+    private class TestIntValidator : BaseStructValidator<int, TestIntValidator>
+    {
+        protected override TestIntValidator Validator => this;
+        public TestIntValidator NotDefault() => IsNotDefault();
+    }
+
+    [Test]
+    [Arguments(0, false)]
+    [Arguments(1, true)]
+    public async Task IsNotDefault_Various(int value, bool expectedSuccess)
+    {
+        var result = new TestIntValidator()
+            .NotDefault()
+            .Validate(value);
+
+        await (expectedSuccess
+            ? Assert.That(result).Succeeded()
+            : Assert.That(result).Failed());
+    }
+}


### PR DESCRIPTION
## Summary
- fix predicate in `BaseStructValidator.IsNotDefault`
- test that default struct values fail validation
- ensure source generation tests validate `Name`

## Testing
- `dotnet test --verbosity normal --logger "console;verbosity=minimal"`

------
https://chatgpt.com/codex/tasks/task_e_68847f2f4abc832484e43ec3999e558c