### PR TITLE
Add validator unit tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@
 - Keep this file updated as packages or build tooling change.
 - Version bump commits on `master` are automatically pushed to `develop` via the workflow.
 - To run tests: `dotnet test --verbosity normal --logger "console;verbosity=minimal"`
+- Source generator tests compile in-memory using `Microsoft.CodeAnalysis.CSharp`.
 
 ## Examples of XML Documentation in Source Code
 

--- a/tests/Olve.Validation.SourceGeneration.Tests/MissingValidatorMethodTests.cs
+++ b/tests/Olve.Validation.SourceGeneration.Tests/MissingValidatorMethodTests.cs
@@ -1,0 +1,73 @@
+using System.Reflection;
+using System.IO;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Olve.Results.TUnit;
+
+namespace Olve.Validation.SourceGeneration.Tests;
+
+public class MissingValidatorMethodTests
+{
+    private static Compilation CreateCompilation(string source)
+    {
+        var references = AppDomain.CurrentDomain.GetAssemblies()
+            .Where(a => !a.IsDynamic && !string.IsNullOrEmpty(a.Location))
+            .Select(a => MetadataReference.CreateFromFile(a.Location));
+
+        return CSharpCompilation.Create(
+            "Test",
+            [CSharpSyntaxTree.ParseText(source)],
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+    }
+
+    [Test]
+    public async Task ReportsDiagnosticWhenMethodMissing()
+    {
+        const string src = """
+using Olve.Validation;
+
+public class Person { public string Name { get; set; } = string.Empty; public int Age { get; set; } }
+
+[ValidatorFor(typeof(Person))]
+public partial class PersonValidator { }
+""";
+        var compilation = CreateCompilation(src);
+        var generatorPath = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory!, "..", "..", "..", "..", "..", "src", "Olve.Validation.SourceGeneration", "bin", "Debug", "netstandard2.0", "Olve.Validation.SourceGeneration.dll"));
+        var generatorAssembly = System.Reflection.Assembly.LoadFrom(generatorPath);
+        var generatorType = generatorAssembly.GetType("Olve.Validation.SourceGeneration.ValidatorForGenerator")!;
+        var generator = (IIncrementalGenerator)Activator.CreateInstance(generatorType)!;
+        var driver = CSharpGeneratorDriver.Create(generator);
+        driver.RunGeneratorsAndUpdateCompilation(compilation, out var output, out var diagnostics);
+        var allDiagnostics = diagnostics.Concat(output.GetDiagnostics());
+
+        await Assert.That(allDiagnostics.Any(d => d.Id == "OVSG001")).IsTrue();
+    }
+
+    [Test]
+    public async Task NoDiagnosticWhenAllMethodsExist()
+    {
+        const string src = """
+using Olve.Validation;
+
+public class Person { public string Name { get; set; } = string.Empty; public int Age { get; set; } }
+
+[ValidatorFor(typeof(Person))]
+public partial class PersonValidator
+{
+    private static IValidator<string> GetNameValidator() => new StringValidator();
+    private static IValidator<int> GetAgeValidator() => new IntValidator();
+}
+""";
+        var compilation = CreateCompilation(src);
+        var generatorPath = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory!, "..", "..", "..", "..", "..", "src", "Olve.Validation.SourceGeneration", "bin", "Debug", "netstandard2.0", "Olve.Validation.SourceGeneration.dll"));
+        var generatorAssembly = System.Reflection.Assembly.LoadFrom(generatorPath);
+        var generatorType = generatorAssembly.GetType("Olve.Validation.SourceGeneration.ValidatorForGenerator")!;
+        var generator = (IIncrementalGenerator)Activator.CreateInstance(generatorType)!;
+        var driver = CSharpGeneratorDriver.Create(generator);
+        driver.RunGeneratorsAndUpdateCompilation(compilation, out var output, out var diagnostics);
+        var allDiagnostics = diagnostics.Concat(output.GetDiagnostics());
+
+        await Assert.That(allDiagnostics.Any(d => d.Id == "OVSG001")).IsFalse();
+    }
+}

--- a/tests/Olve.Validation.SourceGeneration.Tests/Olve.Validation.SourceGeneration.Tests.csproj
+++ b/tests/Olve.Validation.SourceGeneration.Tests/Olve.Validation.SourceGeneration.Tests.csproj
@@ -4,6 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="TUnit" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Olve.Validation.SourceGeneration\Olve.Validation.SourceGeneration.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer" />

--- a/tests/Olve.Validation.SourceGeneration.Tests/ValidatorForGeneratorTests.cs
+++ b/tests/Olve.Validation.SourceGeneration.Tests/ValidatorForGeneratorTests.cs
@@ -11,7 +11,7 @@ public class MyDto
 [ValidatorFor(typeof(MyDto))]
 public partial class MyDtoValidator
 {
-    private static IValidator<string> GetNameValidator() => new StringValidator();
+    private static IValidator<string> GetNameValidator() => new StringValidator().IsNotNullOrWhiteSpace();
     
     private static IValidator<int> GetAgeValidator() => new IntValidator()
         .IsPositive()

--- a/tests/Olve.Validation.Tests/DecimalValidatorTests.cs
+++ b/tests/Olve.Validation.Tests/DecimalValidatorTests.cs
@@ -1,0 +1,34 @@
+using Olve.Results.TUnit;
+
+namespace Olve.Validation.Tests;
+
+public class DecimalValidatorTests
+{
+    [Test]
+    [Arguments(1.0, true)]
+    [Arguments(-1.0, false)]
+    public async Task IsPositive_Various(double value, bool expected)
+    {
+        var validator = new DecimalValidator<double>()
+            .IsPositive();
+        var result = validator.Validate(value);
+
+        await (expected
+            ? Assert.That(result).Succeeded()
+            : Assert.That(result).Failed());
+    }
+
+    [Test]
+    [Arguments(0.0, true)]
+    [Arguments(1.0, false)]
+    public async Task IsZero_Various(double value, bool expected)
+    {
+        var validator = new DecimalValidator<double>()
+            .IsZero();
+        var result = validator.Validate(value);
+
+        await (expected
+            ? Assert.That(result).Succeeded()
+            : Assert.That(result).Failed());
+    }
+}

--- a/tests/Olve.Validation.Tests/IntValidatorTests.cs
+++ b/tests/Olve.Validation.Tests/IntValidatorTests.cs
@@ -1,0 +1,53 @@
+using Olve.Results;
+using Olve.Results.TUnit;
+
+namespace Olve.Validation.Tests;
+
+public class IntValidatorTests
+{
+    [Test]
+    [Arguments(2, true)]
+    [Arguments(3, false)]
+    public async Task IsEven_Various(int value, bool expected)
+    {
+        var result = new IntValidator()
+            .IsEven()
+            .Validate(value);
+
+        await (expected
+            ? Assert.That(result).Succeeded()
+            : Assert.That(result).Failed());
+
+        if (!expected)
+        {
+            await Assert.That(result)
+                .FailedAndProblemCollection()
+                .HasSingleItem()
+                .HasMember(x => x.Single().Message)
+                .EqualTo("Value must be even");
+        }
+    }
+
+    [Test]
+    [Arguments(1, true)]
+    [Arguments(2, false)]
+    public async Task IsOdd_Various(int value, bool expected)
+    {
+        var result = new IntValidator()
+            .IsOdd()
+            .Validate(value);
+
+        await (expected
+            ? Assert.That(result).Succeeded()
+            : Assert.That(result).Failed());
+
+        if (!expected)
+        {
+            await Assert.That(result)
+                .FailedAndProblemCollection()
+                .HasSingleItem()
+                .HasMember(x => x.Single().Message)
+                .EqualTo("Value must be odd");
+        }
+    }
+}

--- a/tests/Olve.Validation.Tests/NumericStructValidatorTests.cs
+++ b/tests/Olve.Validation.Tests/NumericStructValidatorTests.cs
@@ -1,0 +1,49 @@
+using Olve.Results.TUnit;
+
+namespace Olve.Validation.Tests;
+
+public class NumericStructValidatorTests
+{
+    [Test]
+    [Arguments(5, 2, true)]
+    [Arguments(1, 2, false)]
+    public async Task IsGreaterThan_Various(int value, int limit, bool expected)
+    {
+        var result = new IntValidator()
+            .IsGreaterThan(limit)
+            .Validate(value);
+
+        await (expected
+            ? Assert.That(result).Succeeded()
+            : Assert.That(result).Failed());
+    }
+
+    [Test]
+    [Arguments(0, 0, true)]
+    [Arguments(1, 0, false)]
+    public async Task IsLessThanOrEqualTo_Various(int value, int limit, bool expected)
+    {
+        var result = new IntValidator()
+            .IsLessThanOrEqualTo(limit)
+            .Validate(value);
+
+        await (expected
+            ? Assert.That(result).Succeeded()
+            : Assert.That(result).Failed());
+    }
+
+    [Test]
+    [Arguments(5, 1, 10, true)]
+    [Arguments(0, 1, 10, false)]
+    [Arguments(11, 1, 10, false)]
+    public async Task IsBetween_Various(int value, int min, int max, bool expected)
+    {
+        var result = new IntValidator()
+            .IsBetween(min, max)
+            .Validate(value);
+
+        await (expected
+            ? Assert.That(result).Succeeded()
+            : Assert.That(result).Failed());
+    }
+}


### PR DESCRIPTION
## Summary
- cover IntValidator, DecimalValidator<T> and NumericStructValidator
- test ValidatorFor generator diagnostics
- update generator test sample to validate name
- note in AGENTS about source generator tests

## Testing
- `dotnet test --verbosity normal --logger "console;verbosity=minimal"`

------
https://chatgpt.com/codex/tasks/task_e_68847f49f3748324abb607755ee1e37b