### PR TITLE
Require passing build/tests before merging to master

### DIFF
--- a/.github/workflows/pr_to_master.yml
+++ b/.github/workflows/pr_to_master.yml
@@ -1,0 +1,38 @@
+name: PR to master
+
+on:
+  pull_request:
+    branches:
+      - master
+
+env:
+  DOTNET_VERSION: 9.0.300
+
+jobs:
+  test-ubuntu:
+    name: Run tests (Ubuntu)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+      - run: dotnet restore
+      - run: dotnet tool restore
+      - run: dotnet build --no-restore -c Release /p:Version="1.0.0"
+      - run: dotnet test --no-restore --no-build -c Release
+
+  test-windows:
+    name: Run tests (Windows)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+      - run: dotnet restore
+      - run: dotnet tool restore
+      - run: dotnet build --no-restore -c Release /p:Version="1.0.0"
+      - run: dotnet test --no-restore --no-build -c Release

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@
 - Version bump commits on `master` are automatically pushed to `develop` via the workflow.
 - To run tests: `dotnet test --verbosity normal --logger "console;verbosity=minimal"`
 - Pull requests to `develop` run Ubuntu and Windows tests. Failures are informational only.
+- Pull requests to `master` build and run tests on Ubuntu and Windows. Merging is blocked if any job fails.
 - Source generator tests compile in-memory using `Microsoft.CodeAnalysis.CSharp`.
 
 ## Examples of XML Documentation in Source Code


### PR DESCRIPTION
## Summary
- add workflow to run build and tests for PRs targeting `master`
- document new merge requirement in AGENTS guidelines

## Testing
- `dotnet test --verbosity normal --logger "console;verbosity=minimal"`

------
https://chatgpt.com/codex/tasks/task_e_6884be0b14008324ac8f74476b670fe1