### PR TITLE
Add Dagger pipeline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,8 @@
 - Pull requests to `develop` run Ubuntu and Windows tests. Failures are informational only.
 - Pull requests to `master` build and run tests on Ubuntu and Windows. Merging is blocked if any job fails.
 - Source generator tests compile in-memory using `Microsoft.CodeAnalysis.CSharp`.
+- `build/main.py` defines a Dagger pipeline that restores, builds, tests, packs
+  and generates DocFX using the `.NET` version from `DOTNET_VERSION`.
 
 ## Examples of XML Documentation in Source Code
 

--- a/build/main.py
+++ b/build/main.py
@@ -1,0 +1,27 @@
+import asyncio
+import os
+import sys
+import dagger
+
+async def main() -> None:
+    version = os.environ.get("DOTNET_VERSION", "9.0.300")
+
+    async with dagger.Connection(dagger.Config(log_output=sys.stderr)) as client:
+        src = (
+            client.container()
+            .from_(f"mcr.microsoft.com/dotnet/sdk:{version}")
+            .with_mounted_directory("/src", client.host().directory("."))
+            .with_workdir("/src")
+        )
+
+        restored = src.with_exec(["dotnet", "restore"])
+        restored = restored.with_exec(["dotnet", "tool", "restore"])
+        built = restored.with_exec(["dotnet", "build", "--no-restore", "-c", "Release"])
+        tested = built.with_exec(["dotnet", "test", "--no-build", "--no-restore", "-c", "Release"])
+        packed = tested.with_exec(["dotnet", "pack", "--no-build", "-c", "Release"])
+        docs = packed.with_exec(["dotnet", "docfx", "docs/docfx.json"])
+
+        await docs.exit_code()
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add Dagger pipeline script under `build/`
- document pipeline in AGENTS.md

## Testing
- `dotnet test --verbosity normal --logger "console;verbosity=minimal"`

------
https://chatgpt.com/codex/tasks/task_e_688729f7b8048324b37eeae2be138eaa