### PR TITLE
docs: fix Olve.Paths README factual error and expand coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@
 - Source generator tests compile in-memory using `Microsoft.CodeAnalysis.CSharp`.
 - `build/main.py` defines a Dagger pipeline that restores, builds, tests, packs
   and generates DocFX using the `.NET` version from `DOTNET_VERSION`.
+- Commit messages should be short: a single subject line using conventional commit format (e.g. `docs: fix Olve.Paths README`). No multi-line body unless truly necessary.
 
 ## Examples of XML Documentation in Source Code
 

--- a/src/Olve.Paths/README.md
+++ b/src/Olve.Paths/README.md
@@ -1,32 +1,40 @@
 # Olve.Paths
-[![NuGet](https://img.shields.io/nuget/v/Olve.Paths?logo=nuget)](https://www.nuget.org/packages/Olve.Paths)[![GitHub](https://img.shields.io/github/license/OliverVea/Olve.Utilities)](LICENSE)![LOC](https://img.shields.io/endpoint?url=https%3A%2F%2Fghloc.vercel.app%2Fapi%2FOliverVea%2FOlve.Paths%2Fbadge)![NuGet Downloads](https://img.shields.io/nuget/dt/Olve.Paths)
 
-A .NET library for working with file and directory paths inspired by Python's `pathlib` module.
+[![NuGet](https://img.shields.io/nuget/v/Olve.Paths?logo=nuget)](https://www.nuget.org/packages/Olve.Paths)
+[![Docs](https://img.shields.io/badge/docs-API%20Reference-blue)](https://olivervea.github.io/Olve.Utilities/api/Olve.Paths.html)
 
-It provides a set of classes and methods to manipulate file paths in a more intuitive and object-oriented way.
+A .NET library for working with file and directory paths inspired by Python's `pathlib` module. It provides an object-oriented interface for manipulating paths in a more intuitive way than raw strings.
 
-## Features
-
-- Object-oriented interface for file and directory paths.
-- Easy navigation and manipulation of paths.
-  - Supports the `/` operator for path joining.
-- Support of different path formats.
-  - Currently, only Unix-style paths are supported.
-
-See [`Olve.Paths.Glob`](https://github.com/OliverVea/Olve.Utilities/tree/master/src/Olve.Paths.Glob) for more information about the globbing functionality.
+---
 
 ## Installation
-
-Simply install the package via NuGet:
 
 ```bash
 dotnet add package Olve.Paths
 ```
 
+---
+
+## Overview
+
+| Type | Description |
+| --- | --- |
+| `IPath` | Environment-aware path with filesystem operations (existence checks, children, element type). |
+| `IPurePath` | Immutable, pure path independent of the filesystem. Useful for manipulation without side effects. |
+| `PathPlatform` | Platform discriminator: `Unix` or `Windows`. |
+| `ElementType` | Filesystem element type: `File`, `Directory`, or `None`. |
+| `PathType` | Path classification: `Absolute`, `Relative`, or `Stub`. |
+
+---
+
 ## Usage
 
+### Path navigation
+
+Create a path with `Path.Create()` and navigate using `Parent`, `Name`, and the `/` operator for joining.
+
 ```cs
-// ../../tests/Olve.Paths.Tests/ReadmeDemo.cs#L18-L24
+// ../../tests/Olve.Paths.Tests/ReadmeDemo.cs#L8-L14
 
 var path = Path.Create("/home/user/documents"); // /home/user/documents
 
@@ -37,4 +45,71 @@ var newPath = path / "newfile.txt"; // /home/user/documents/newfile.txt
 var exists = newPath.Exists(); // Check if the file exists
 ```
 
-See the [API documentation](https://olivervea.github.io/Olve.Utilities/api/) for more details.
+On Windows the same API applies with backslash-separated paths:
+
+```cs
+// ../../tests/Olve.Paths.Tests/ReadmeDemo.cs#L28-L34
+
+var path = Path.Create(@"C:\users\user\documents"); // C:\users\user\documents
+
+var parent = path.Parent; // C:\users\user
+var folderName = path.Name; // documents
+
+var newPath = path / "newfile.txt"; // C:\users\user\documents\newfile.txt
+var exists = newPath.Exists(); // Check if the file exists
+```
+
+### Pure paths
+
+`Path.CreatePure()` creates immutable paths that work on any platform without touching the filesystem. Pass a `PathPlatform` to create paths for a specific platform regardless of the host OS.
+
+```cs
+// ../../tests/Olve.Paths.Tests/ReadmeDemo.cs#L48-L53
+
+// Pure paths allow platform-independent path manipulation
+var unixPath = Path.CreatePure("/home/user/docs", PathPlatform.Unix);
+var windowsPath = Path.CreatePure(@"C:\users\user\docs", PathPlatform.Windows);
+
+var unixPlatform = unixPath.Platform; // PathPlatform.Unix
+var windowsPlatform = windowsPath.Platform; // PathPlatform.Windows
+```
+
+### Filesystem operations
+
+`IPath` provides methods for querying and manipulating the filesystem: `Exists()`, `ElementType`, `TryGetChildren()`, and `EnsurePathExists()`.
+
+```cs
+// ../../tests/Olve.Paths.Tests/ReadmeDemo.cs#L66-L78
+
+var tempDir = Path.Create(System.IO.Path.GetTempPath()) / "olve-paths-demo";
+tempDir.EnsurePathExists(); // Creates the directory if it doesn't exist
+
+var exists = tempDir.Exists(); // true
+var elementType = tempDir.ElementType; // ElementType.Directory
+
+if (tempDir.TryGetChildren(out var children))
+{
+    foreach (var child in children)
+    {
+        Console.WriteLine(child.Path);
+    }
+}
+```
+
+---
+
+## Globbing
+
+See [`Olve.Paths.Glob`](https://github.com/OliverVea/Olve.Utilities/tree/master/src/Olve.Paths.Glob) for wildcard pattern matching on paths.
+
+---
+
+## Documentation
+
+Full API reference: [https://olivervea.github.io/Olve.Utilities/api/Olve.Paths.html](https://olivervea.github.io/Olve.Utilities/api/Olve.Paths.html)
+
+---
+
+## License
+
+MIT License © [OliverVea](https://github.com/OliverVea)

--- a/tests/Olve.Paths.Tests/ReadmeDemo.cs
+++ b/tests/Olve.Paths.Tests/ReadmeDemo.cs
@@ -2,19 +2,9 @@ namespace Olve.Paths.Tests;
 
 public class ReadmeDemo
 {
-    [Test]
-    public Task Snippet1()
+    [Test, LinuxOnly]
+    public async Task Snippet1_Linux()
     {
-        if (OperatingSystem.IsWindows()) return WindowsSnippet1();
-        if (OperatingSystem.IsLinux()) return UnixSnippet1();
-        
-        Assert.Fail("Platform not supported");
-        return Task.CompletedTask;
-    }
-
-    private async Task UnixSnippet1()
-    {
-        // Snippet 1
         var path = Path.Create("/home/user/documents"); // /home/user/documents
 
         var parent = path.Parent; // /home/user
@@ -32,9 +22,10 @@ public class ReadmeDemo
         await Assert.That(exists).IsEqualTo(actuallyExists);
     }
 
-    private async Task WindowsSnippet1()
+    [Test, WindowsOnly]
+    public async Task Snippet1_Windows()
     {
-        var path = Path.Create(@"C:\users\user\documents");
+        var path = Path.Create(@"C:\users\user\documents"); // C:\users\user\documents
 
         var parent = path.Parent; // C:\users\user
         var folderName = path.Name; // documents
@@ -49,6 +40,48 @@ public class ReadmeDemo
 
         var actuallyExists = File.Exists(newPath.Path);
         await Assert.That(exists).IsEqualTo(actuallyExists);
-        
+    }
+
+    [Test]
+    public async Task Snippet2()
+    {
+        // Pure paths allow platform-independent path manipulation
+        var unixPath = Path.CreatePure("/home/user/docs", PathPlatform.Unix);
+        var windowsPath = Path.CreatePure(@"C:\users\user\docs", PathPlatform.Windows);
+
+        var unixPlatform = unixPath.Platform; // PathPlatform.Unix
+        var windowsPlatform = windowsPath.Platform; // PathPlatform.Windows
+
+        // Assert
+        await Assert.That(unixPlatform).IsEqualTo(PathPlatform.Unix);
+        await Assert.That(windowsPlatform).IsEqualTo(PathPlatform.Windows);
+        await Assert.That(unixPath.Path).IsEqualTo("/home/user/docs");
+        await Assert.That(windowsPath.Path).IsEqualTo(@"C:\users\user\docs");
+    }
+
+    [Test]
+    public async Task Snippet3()
+    {
+        // Filesystem operations
+        var tempDir = Path.Create(System.IO.Path.GetTempPath()) / "olve-paths-demo";
+        tempDir.EnsurePathExists(); // Creates the directory if it doesn't exist
+
+        var exists = tempDir.Exists(); // true
+        var elementType = tempDir.ElementType; // ElementType.Directory
+
+        if (tempDir.TryGetChildren(out var children))
+        {
+            foreach (var child in children)
+            {
+                Console.WriteLine(child.Path);
+            }
+        }
+
+        // Cleanup
+        Directory.Delete(tempDir.Path, true);
+
+        // Assert
+        await Assert.That(exists).IsTrue();
+        await Assert.That(elementType).IsEqualTo(ElementType.Directory);
     }
 }


### PR DESCRIPTION
## Summary
- Fixes incorrect claim that "only Unix-style paths are supported" — Windows is fully implemented
- Adds type overview table, pure paths section, and filesystem operations section
- Refactors ReadmeDemo tests to use `[LinuxOnly]`/`[WindowsOnly]` attributes
- Adds concise commit message guideline to AGENTS.md

Closes #49

## Test plan
- [x] `dotnet test` passes (62 tests, 56 succeeded, 6 skipped on Linux)
- [x] `npx embedme --verify` passes
- [ ] CI passes on both Ubuntu and Windows

🤖 Generated with [Claude Code](https://claude.ai/code)