### PR TITLE
feat: add olve-packages Claude Code plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,14 @@
+{
+  "name": "olve-packages",
+  "owner": { "name": "Oliver Vea" },
+  "metadata": {
+    "description": "Olve.* shared NuGet package skills for Claude Code"
+  },
+  "plugins": [
+    {
+      "name": "olve-packages",
+      "source": "./olve-packages",
+      "description": "API references and usage guides for Olve.* shared NuGet packages"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -30,6 +30,20 @@ Full API documentation: [olivervea.github.io/Olve.Utilities](https://olivervea.g
 
 ---
 
+## Claude Code Skills
+
+This repo includes a [Claude Code plugin](olve-packages/) with API reference skills for each package. To install in a downstream project:
+
+```bash
+# Add the marketplace (one-time)
+claude plugin marketplace add OliverVea/Olve.Utilities --sparse .claude-plugin olve-packages
+
+# Install the plugin
+claude plugin install olve-packages --scope project
+```
+
+---
+
 ## License
 
 MIT License © [OliverVea](https://github.com/OliverVea)

--- a/olve-packages/.claude-plugin/plugin.json
+++ b/olve-packages/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "olve-packages",
+  "description": "API references and usage guides for Olve.* shared NuGet packages",
+  "version": "1.0.0",
+  "author": { "name": "Oliver Vea" },
+  "repository": "https://github.com/OliverVea/Olve.Utilities",
+  "license": "MIT"
+}

--- a/olve-packages/skills/olve-minimal-api/SKILL.md
+++ b/olve-packages/skills/olve-minimal-api/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: olve-minimal-api
+description: Reference for Olve.MinimalApi — ASP.NET Core Minimal API extensions for Result mapping to HTTP responses, endpoint validation filters, handler interfaces, and IPath JSON conversion. Use when writing or reading code that integrates Olve.Results with Minimal API endpoints.
+user-invocable: false
+---
+
+# Olve.MinimalApi
+
+ASP.NET Core Minimal API extensions for [Olve.Results](https://www.nuget.org/packages/Olve.Results). Source: `Olve.Utilities/src/Olve.MinimalApi/`.
+
+Reference docs: [README](references/README.md) | [Handlers](references/Handlers.md) | [ResultMapping](references/ResultMapping.md) | [Validation](references/Validation.md) | [Services](references/Services.md)
+
+## Result Mapping
+
+Map `Result` / `Result<T>` return values to HTTP responses automatically:
+
+```csharp
+// Generic — 200 OK with body or 400 Bad Request
+app.MapGet("/users/{id}", (int id, UserHandler handler, CancellationToken ct)
+        => handler.HandleAsync(new GetUser(id), ct))
+    .WithResultMapping<UserDto>();
+
+// Non-generic — 200 OK (empty) or 400 Bad Request
+app.MapDelete("/users/{id}", (int id, DeleteHandler handler, CancellationToken ct)
+        => handler.RunAsync(new DeleteUser(id), ct))
+    .WithResultMapping();
+```
+
+| Return value | HTTP response |
+| --- | --- |
+| `Result` success | 200 OK (empty body) |
+| `Result<T>` success | 200 OK with `T` as body |
+| Any failure | 400 Bad Request with `ResultProblem[]` as body |
+
+## Validation
+
+Add validation filters using `IValidator<T>` from Olve.Validation:
+
+```csharp
+app.MapPost("/users", (CreateUserRequest request, UserHandler handler, CancellationToken ct)
+        => handler.HandleAsync(request, ct))
+    .WithResultMapping<UserDto>()
+    .WithValidation<CreateUserRequest, CreateUserValidator>();
+```
+
+## Handler Interfaces
+
+```csharp
+// No return value (delete, update)
+public class MyHandler : IHandler<MyRequest>
+{
+    public Task<Result> RunAsync(MyRequest request, CancellationToken ct) { ... }
+}
+
+// With return value (get, create)
+public class MyHandler : IHandler<MyRequest, MyResponse>
+{
+    public Task<Result<MyResponse>> HandleAsync(MyRequest request, CancellationToken ct) { ... }
+}
+```
+
+## Path JSON Conversion
+
+```csharp
+builder.Services.WithPathJsonConversion();
+```

--- a/olve-packages/skills/olve-minimal-api/references/Handlers.md
+++ b/olve-packages/skills/olve-minimal-api/references/Handlers.md
@@ -1,0 +1,51 @@
+# Handler Interfaces
+
+API docs: [https://olivervea.github.io/Olve.Utilities/api/Olve.MinimalApi.html](https://olivervea.github.io/Olve.Utilities/api/Olve.MinimalApi.html)
+
+Namespace: `Olve.MinimalApi`
+
+## IHandler\<TRequest\>
+
+Handler for operations that return no value (e.g. delete, update).
+
+```csharp
+public interface IHandler<in TRequest>
+{
+    Task<Result> RunAsync(TRequest request, CancellationToken cancellationToken);
+}
+```
+
+### Members
+
+| Member | Signature |
+| --- | --- |
+| `RunAsync` | `Task<Result> RunAsync(TRequest request, CancellationToken cancellationToken)` |
+
+## IHandler\<TRequest, TResponse\>
+
+Handler for operations that return a value (e.g. get, create).
+
+```csharp
+public interface IHandler<in TRequest, TResponse>
+{
+    Task<Result<TResponse>> HandleAsync(TRequest request, CancellationToken cancellationToken);
+}
+```
+
+### Members
+
+| Member | Signature |
+| --- | --- |
+| `HandleAsync` | `Task<Result<TResponse>> HandleAsync(TRequest request, CancellationToken cancellationToken)` |
+
+## Usage
+
+```csharp
+// Register as a service
+builder.Services.AddScoped<IHandler<GetUser, UserDto>, GetUserHandler>();
+
+// Wire to endpoint
+app.MapGet("/users/{id}", (int id, IHandler<GetUser, UserDto> handler, CancellationToken ct)
+        => handler.HandleAsync(new GetUser(id), ct))
+    .WithResultMapping<UserDto>();
+```

--- a/olve-packages/skills/olve-minimal-api/references/README.md
+++ b/olve-packages/skills/olve-minimal-api/references/README.md
@@ -1,0 +1,27 @@
+# Olve.MinimalApi — Overview
+
+API docs: [https://olivervea.github.io/Olve.Utilities/api/Olve.MinimalApi.html](https://olivervea.github.io/Olve.Utilities/api/Olve.MinimalApi.html)
+
+NuGet: [Olve.MinimalApi](https://www.nuget.org/packages/Olve.MinimalApi)
+
+## Summary
+
+ASP.NET Core Minimal API extensions for Olve.Results. Maps `Result` and `Result<T>` to HTTP responses, adds endpoint validation filters using `IValidator<T>`, and provides JSON conversion for `IPath`.
+
+## Types
+
+| Type | Description |
+| --- | --- |
+| `ResultMappingExtensions` | Maps `Result` / `Result<T>` to 200 OK or 400 Bad Request responses. |
+| `ValidationApiExtensions` | Adds endpoint validation filters using `IValidator<T>`. |
+| `IHandler<TRequest>` | Handler interface for operations returning `Result` (no value). |
+| `IHandler<TRequest, TResponse>` | Handler interface for operations returning `Result<TResponse>`. |
+| `PathJsonConverter` | JSON converter for `IPath` round-trip serialization. |
+| `ServiceExtensions` | Registers `PathJsonConverter` in JSON options. |
+
+## Dependencies
+
+- `Olve.Results` — Result types and `ResultProblem`
+- `Olve.Validation` — `IValidator<T>` interface
+- `Olve.Paths` — `IPath` interface
+- `Microsoft.AspNetCore.App` — Minimal API framework

--- a/olve-packages/skills/olve-minimal-api/references/ResultMapping.md
+++ b/olve-packages/skills/olve-minimal-api/references/ResultMapping.md
@@ -1,0 +1,58 @@
+# ResultMappingExtensions
+
+API docs: [https://olivervea.github.io/Olve.Utilities/api/Olve.MinimalApi.ResultMappingExtensions.html](https://olivervea.github.io/Olve.Utilities/api/Olve.MinimalApi.ResultMappingExtensions.html)
+
+Namespace: `Olve.MinimalApi`
+
+Static class providing extension methods to map `Result` and `Result<T>` to Minimal API HTTP responses.
+
+## Public Members
+
+| Member | Signature |
+| --- | --- |
+| `WithResultMapping` | `static RouteHandlerBuilder WithResultMapping(this RouteHandlerBuilder builder)` |
+| `WithResultMapping<TResult>` | `static RouteHandlerBuilder WithResultMapping<TResult>(this RouteHandlerBuilder builder)` |
+| `ToHttpResult` | `static IResult ToHttpResult(this Result result)` |
+| `ToHttpResult<T>` | `static IResult ToHttpResult<T>(this Result<T> result)` |
+
+## WithResultMapping (non-generic)
+
+Configures the endpoint to produce 200 OK (empty body) on success or 400 Bad Request with `ResultProblem[]` on failure. Used when the handler returns `Result`.
+
+```csharp
+app.MapDelete("/users/{id}", (int id, DeleteHandler handler, CancellationToken ct)
+        => handler.RunAsync(new DeleteUser(id), ct))
+    .WithResultMapping();
+```
+
+## WithResultMapping\<TResult\>
+
+Configures the endpoint to produce 200 OK with `TResult` body on success or 400 Bad Request with `ResultProblem[]` on failure. Used when the handler returns `Result<TResult>`.
+
+```csharp
+app.MapGet("/users/{id}", (int id, UserHandler handler, CancellationToken ct)
+        => handler.HandleAsync(new GetUser(id), ct))
+    .WithResultMapping<UserDto>();
+```
+
+## ToHttpResult
+
+Converts a `Result` directly into an `IResult` HTTP response. Returns `TypedResults.Ok()` on success or `TypedResults.BadRequest(problems.ToArray())` on failure.
+
+```csharp
+Result result = DoSomething();
+return result.ToHttpResult();
+```
+
+## ToHttpResult\<T\>
+
+Converts a `Result<T>` directly into an `IResult` HTTP response. Returns `TypedResults.Ok(value)` on success or `TypedResults.BadRequest(problems.ToArray())` on failure.
+
+```csharp
+Result<string> result = GetValue();
+return result.ToHttpResult();
+```
+
+## Behavior
+
+The `WithResultMapping` methods add an endpoint filter factory that inspects the handler return type at startup. At runtime the filter unwraps `Result` / `Result<T>` (including `Task<Result>` / `Task<Result<T>>`) and converts to the appropriate HTTP response.

--- a/olve-packages/skills/olve-minimal-api/references/Services.md
+++ b/olve-packages/skills/olve-minimal-api/references/Services.md
@@ -1,0 +1,43 @@
+# ServiceExtensions and PathJsonConverter
+
+API docs: [https://olivervea.github.io/Olve.Utilities/api/Olve.MinimalApi.ServiceExtensions.html](https://olivervea.github.io/Olve.Utilities/api/Olve.MinimalApi.ServiceExtensions.html)
+
+Namespace: `Olve.MinimalApi`
+
+## ServiceExtensions
+
+Static class providing extension methods to configure Minimal API services.
+
+### Public Members
+
+| Member | Signature |
+| --- | --- |
+| `WithPathJsonConversion` | `static IServiceCollection WithPathJsonConversion(this IServiceCollection services)` |
+
+### WithPathJsonConversion
+
+Registers `PathJsonConverter` in the default `JsonSerializerOptions` via `ConfigureHttpJsonOptions`, enabling JSON round-trip serialization of `IPath` values in request/response models.
+
+```csharp
+builder.Services.WithPathJsonConversion();
+```
+
+Returns the `IServiceCollection` for chaining.
+
+---
+
+## PathJsonConverter
+
+Sealed class that extends `JsonConverter<IPath>` for JSON serialization of `IPath` instances.
+
+### Public Members
+
+| Member | Signature |
+| --- | --- |
+| `Read` | `override IPath? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)` |
+| `Write` | `override void Write(Utf8JsonWriter writer, IPath value, JsonSerializerOptions options)` |
+
+### Behavior
+
+- **Read**: Reads a JSON string and converts it to an `IPath` via `Path.Create(pathString)`. Returns `null` if the JSON value is null.
+- **Write**: Writes the `IPath.Path` property as a JSON string value.

--- a/olve-packages/skills/olve-minimal-api/references/Validation.md
+++ b/olve-packages/skills/olve-minimal-api/references/Validation.md
@@ -1,0 +1,41 @@
+# ValidationApiExtensions
+
+API docs: [https://olivervea.github.io/Olve.Utilities/api/Olve.MinimalApi.ValidationApiExtensions.html](https://olivervea.github.io/Olve.Utilities/api/Olve.MinimalApi.ValidationApiExtensions.html)
+
+Namespace: `Olve.MinimalApi`
+
+Static class providing extension methods to add validation filters for Minimal API endpoints using `IValidator<T>` from `Olve.Validation`.
+
+## Public Members
+
+| Member | Signature |
+| --- | --- |
+| `WithValidation<TRequest, TValidator>` | `static RouteHandlerBuilder WithValidation<TRequest, TValidator>(this RouteHandlerBuilder builder) where TValidator : IValidator<TRequest>, new()` |
+| `WithValidation<TRequest, TValidator>` | `static RouteHandlerBuilder WithValidation<TRequest, TValidator>(this RouteHandlerBuilder builder, TValidator validator) where TValidator : IValidator<TRequest>` |
+
+## WithValidation (parameterless)
+
+Creates a new `TValidator` instance and adds a validation endpoint filter. The validator must have a parameterless constructor.
+
+```csharp
+app.MapPost("/users", (CreateUserRequest request, UserHandler handler, CancellationToken ct)
+        => handler.HandleAsync(request, ct))
+    .WithResultMapping<UserDto>()
+    .WithValidation<CreateUserRequest, CreateUserValidator>();
+```
+
+## WithValidation (with instance)
+
+Adds a validation endpoint filter using the provided validator instance.
+
+```csharp
+var validator = new CreateUserValidator();
+app.MapPost("/users", (CreateUserRequest request, UserHandler handler, CancellationToken ct)
+        => handler.HandleAsync(request, ct))
+    .WithResultMapping<UserDto>()
+    .WithValidation<CreateUserRequest, CreateUserValidator>(validator);
+```
+
+## Behavior
+
+The filter extracts the first `TRequest` argument from the endpoint invocation context. If found, it runs `validator.Validate(request)`. On validation failure, it short-circuits and returns the validation result as an HTTP response via `ToHttpResult()`. If no `TRequest` argument is found, the filter passes through to the next handler.

--- a/olve-packages/skills/olve-openraster/SKILL.md
+++ b/olve-packages/skills/olve-openraster/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: olve-openraster
+description: Reference for Olve.OpenRaster — read-only access to OpenRaster (.ora) layered image files, including layer/group metadata, composite operations, and custom layer parsing via ILayerParser<T>. Use when writing or reading code that works with .ora files.
+user-invocable: false
+---
+
+# Olve.OpenRaster
+
+Read-only access to [OpenRaster](https://www.openraster.org/) (`.ora`) layered image files. Source: `Olve.Utilities/src/Olve.OpenRaster/`.
+
+Reference docs: [README](references/README.md) | [Models](references/Models.md) | [Operations](references/Operations.md)
+
+API docs: [https://olivervea.github.io/Olve.Utilities/api/Olve.OpenRaster.html](https://olivervea.github.io/Olve.Utilities/api/Olve.OpenRaster.html)
+
+## Quick usage
+
+### Read an .ora file
+
+```csharp
+var operation = new ReadOpenRasterFile();
+var request = new ReadOpenRasterFile.Request(filePath);
+
+var result = operation.Execute(request);
+if (result.TryPickProblems(out var problems, out var file))
+{
+    return problems.Prepend("Failed to read .ora file");
+}
+
+// file.Version, file.Width, file.Height, file.Layers, file.Groups
+```
+
+### Inspect layers
+
+```csharp
+foreach (var layer in file.Layers)
+{
+    // layer.Name, layer.Source, layer.Opacity, layer.Visible
+    // layer.X, layer.Y, layer.CompositeOperation, layer.Groups
+}
+```
+
+### Read a layer image with a custom parser
+
+```csharp
+public class PngLayerParser : ILayerParser<Png>
+{
+    public Result<Png> ParseLayer(Stream stream)
+    {
+        var ms = new MemoryStream();
+        stream.CopyTo(ms);
+        ms.Position = 0;
+        return Png.Open(ms);
+    }
+}
+
+var parser = new PngLayerParser();
+var request = new ReadLayerAs<Png>.Request(filePath, "data/layer0.png", parser);
+var result = new ReadLayerAs<Png>().Execute(request);
+```
+
+### Composite operations
+
+```csharp
+var result = CompositeOperation.FromKey("svg:multiply");
+if (result.TryPickValue(out var op, out _))
+{
+    // op.BlendingFunction == BlendingFunction.Multiply
+    // op.CompositingOperator == CompositingOperator.SourceOver
+}
+```
+
+## Key points
+
+- All operations return `Result<T>` from `Olve.Results` -- never throws.
+- The library does NOT bundle an image decoder. Implement `ILayerParser<T>` with your preferred image library.
+- `.ora` files are ZIP archives containing `stack.xml` (metadata) and layer image files.
+- Layers track their parent `Group`s and groups track their child `Layer`s (bidirectional).

--- a/olve-packages/skills/olve-openraster/references/Models.md
+++ b/olve-packages/skills/olve-openraster/references/Models.md
@@ -1,0 +1,173 @@
+# Olve.OpenRaster -- Models
+
+API docs: [https://olivervea.github.io/Olve.Utilities/api/Olve.OpenRaster.html](https://olivervea.github.io/Olve.Utilities/api/Olve.OpenRaster.html)
+
+Source: `src/Olve.OpenRaster/Models/`
+
+## OpenRasterFile
+
+Represents the content of an OpenRaster (`.ora`) file.
+
+```csharp
+public class OpenRasterFile
+{
+    public required string Version { get; set; }
+    public required int Width { get; set; }
+    public required int Height { get; set; }
+    public int XResolution { get; set; } = 72;
+    public int YResolution { get; set; } = 72;
+    public IReadOnlyList<Layer> Layers { get; set; } = [];
+    public IReadOnlyList<Group> Groups { get; set; } = [];
+}
+```
+
+- `Version` -- OpenRaster format version (e.g. `"0.0.5"`).
+- `Width`, `Height` -- canvas dimensions in pixels.
+- `XResolution`, `YResolution` -- DPI, defaults to 72.
+- `Layers` -- flat list of all layers in the file.
+- `Groups` -- flat list of all groups (stacks) in the file.
+
+## Layer
+
+Represents a layer element in the layer stack.
+
+```csharp
+public class Layer
+{
+    public required string Name { get; set; }
+    public required string Source { get; set; }
+    public CompositeOperation CompositeOperation { get; set; } = CompositeOperation.SrcOver;
+    public float Opacity { get; set; } = 1.0f;
+    public bool Visible { get; set; } = true;
+    public int X { get; set; } = 0;
+    public int Y { get; set; } = 0;
+    public IList<Group> Groups { get; set; } = [];
+}
+```
+
+- `Name` -- layer name from the `name` attribute.
+- `Source` -- path to the layer image within the ZIP (e.g. `"data/layer0.png"`).
+- `CompositeOperation` -- blend mode, defaults to `SrcOver`.
+- `Opacity` -- 0.0 (transparent) to 1.0 (opaque), defaults to 1.0.
+- `Visible` -- visibility, defaults to `true`.
+- `X`, `Y` -- position offset relative to the canvas.
+- `Groups` -- parent groups this layer belongs to (bidirectional link).
+
+## Group
+
+A group of layers (corresponds to a `<stack>` element).
+
+```csharp
+public class Group
+{
+    public required string Name { get; set; }
+    public CompositeOperation CompositeOperation { get; set; } = CompositeOperation.SrcOver;
+    public float Opacity { get; set; } = 1.0f;
+    public Visibility Visibility { get; set; } = Visibility.Visible;
+    [Obsolete] public int X { get; set; }
+    [Obsolete] public int Y { get; set; }
+    public IList<Layer> Layers { get; set; } = [];
+}
+```
+
+- `Name` -- group name.
+- `Visibility` -- uses the `Visibility` enum (not a plain `bool` like `Layer`).
+- `Layers` -- child layers in this group (bidirectional link).
+- `X`, `Y` -- deprecated since OpenRaster 0.0.6.
+
+## CompositeOperation
+
+A record struct combining a blending function and compositing operator with its SVG key string.
+
+```csharp
+public readonly record struct CompositeOperation(
+    string Key,
+    BlendingFunction BlendingFunction,
+    CompositingOperator CompositingOperator);
+```
+
+### Static presets
+
+| Property | Key | BlendingFunction | CompositingOperator |
+| --- | --- | --- | --- |
+| `SrcOver` | `svg:src-over` | `Normal` | `SourceOver` |
+| `Multiply` | `svg:multiply` | `Multiply` | `SourceOver` |
+| `Screen` | `svg:screen` | `Screen` | `SourceOver` |
+| `Overlay` | `svg:overlay` | `Overlay` | `SourceOver` |
+| `Darken` | `svg:darken` | `Darken` | `SourceOver` |
+| `Lighten` | `svg:lighten` | `Lighten` | `SourceOver` |
+| `ColorDodge` | `svg:color-dodge` | `ColorDodge` | `SourceOver` |
+| `ColorBurn` | `svg:color-burn` | `ColorBurn` | `SourceOver` |
+| `HardLight` | `svg:hard-light` | `HardLight` | `SourceOver` |
+| `SoftLight` | `svg:soft-light` | `SoftLight` | `SourceOver` |
+| `Difference` | `svg:difference` | `Difference` | `SourceOver` |
+| `Color` | `svg:color` | `Color` | `SourceOver` |
+| `Luminosity` | `svg:luminosity` | `Luminosity` | `SourceOver` |
+| `Hue` | `svg:hue` | `Hue` | `SourceOver` |
+| `Saturation` | `svg:saturation` | `Saturation` | `SourceOver` |
+| `Plus` | `svg:plus` | `Normal` | `Lighter` |
+| `DestinationIn` | `svg:dst-in` | `Normal` | `DestinationIn` |
+| `DestinationOut` | `svg:dst-out` | `Normal` | `DestinationOut` |
+| `SourceAtop` | `svg:src-atop` | `Normal` | `SourceAtop` |
+| `DestinationAtop` | `svg:dst-atop` | `Normal` | `DestinationAtop` |
+
+### Methods
+
+```csharp
+public static Result<CompositeOperation> FromKey(string key);
+```
+
+Parses an SVG key string (e.g. `"svg:multiply"`) into the corresponding preset. Returns a `ResultProblem` for unknown keys.
+
+## BlendingFunction
+
+Enum defining how colors are blended between layers. Follows the [W3C Compositing and Blending](https://www.w3.org/TR/compositing-1/) specification.
+
+```csharp
+public enum BlendingFunction
+{
+    Normal,
+    Multiply,
+    Screen,
+    Overlay,
+    Darken,
+    Lighten,
+    ColorDodge,
+    ColorBurn,
+    HardLight,
+    SoftLight,
+    Difference,
+    Color,
+    Luminosity,
+    Hue,
+    Saturation
+}
+```
+
+## CompositingOperator
+
+Enum defining how alpha channels interact during compositing.
+
+```csharp
+public enum CompositingOperator
+{
+    SourceOver,
+    Lighter,
+    DestinationIn,
+    DestinationOut,
+    SourceAtop,
+    DestinationAtop
+}
+```
+
+## Visibility
+
+Enum for layer/group visibility state.
+
+```csharp
+public enum Visibility
+{
+    Hidden = 0,
+    Visible = 1
+}
+```

--- a/olve-packages/skills/olve-openraster/references/Operations.md
+++ b/olve-packages/skills/olve-openraster/references/Operations.md
@@ -1,0 +1,135 @@
+# Olve.OpenRaster -- Operations
+
+API docs: [https://olivervea.github.io/Olve.Utilities/api/Olve.OpenRaster.html](https://olivervea.github.io/Olve.Utilities/api/Olve.OpenRaster.html)
+
+Source: `src/Olve.OpenRaster/Operations/`
+
+## ReadOpenRasterFile
+
+Reads and validates an OpenRaster (`.ora`) file, extracting metadata, layers, and groups.
+
+Implements `IOperation<ReadOpenRasterFile.Request, OpenRasterFile>`.
+
+```csharp
+public class ReadOpenRasterFile : IOperation<ReadOpenRasterFile.Request, OpenRasterFile>
+{
+    public record Request(string FilePath);
+
+    public Result<OpenRasterFile> Execute(Request request);
+}
+```
+
+### Usage
+
+```csharp
+var operation = new ReadOpenRasterFile();
+var request = new ReadOpenRasterFile.Request(filePath);
+
+var result = operation.Execute(request);
+if (result.TryPickProblems(out var problems, out var file))
+{
+    return problems.Prepend("Failed to read .ora file");
+}
+
+// file.Version, file.Width, file.Height
+// file.Layers -- flat list of all layers
+// file.Groups -- flat list of all groups
+```
+
+### Behavior
+
+- Validates the file path exists and is non-empty.
+- Opens the `.ora` file as a ZIP archive.
+- Parses `stack.xml` to build the full `OpenRasterFile` model.
+- Establishes bidirectional links between layers and groups.
+- Returns `ResultProblem` for invalid paths, missing files, or malformed XML.
+
+## ReadLayerAs\<T\>
+
+Loads a specific layer's image data from an `.ora` file and parses it into a custom type using an `ILayerParser<T>`.
+
+Implements `IOperation<ReadLayerAs<T>.Request, T>`.
+
+```csharp
+public class ReadLayerAs<T> : IOperation<ReadLayerAs<T>.Request, T>
+{
+    public record Request(string FilePath, string LayerSource, ILayerParser<T> LayerParser);
+
+    public Result<T> Execute(Request request);
+}
+```
+
+### Usage
+
+```csharp
+var parser = new PngLayerParser();
+var request = new ReadLayerAs<Png>.Request(filePath, "data/layer0.png", parser);
+
+var result = new ReadLayerAs<Png>().Execute(request);
+if (result.TryPickProblems(out var problems, out var png))
+{
+    return problems.Prepend("Failed to read layer image");
+}
+
+// png.Width, png.Height, etc.
+```
+
+### Behavior
+
+- Validates the file path.
+- Opens the `.ora` ZIP archive.
+- Locates the entry matching `LayerSource` within the archive.
+- Passes the entry stream to `ILayerParser<T>.ParseLayer`.
+- Returns `ResultProblem` if the file is invalid, the layer entry is missing, or the parser fails.
+
+### Request parameters
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `FilePath` | `string` | Path to the `.ora` file. |
+| `LayerSource` | `string` | Layer source path within the ZIP (from `Layer.Source`, e.g. `"data/layer0.png"`). |
+| `LayerParser` | `ILayerParser<T>` | Parser implementation to convert the stream into `T`. |
+
+## ILayerParser\<T\>
+
+Interface for converting a layer's byte stream into a custom type. The library does not bundle any image decoder -- implement this with your preferred image library.
+
+```csharp
+public interface ILayerParser<T>
+{
+    Result<T> ParseLayer(Stream stream);
+}
+```
+
+### Parameters
+
+- `stream` -- positioned at the beginning of the layer's image data from the ZIP entry.
+
+### Example implementation (BigGustave)
+
+```csharp
+public class PngLayerParser : ILayerParser<Png>
+{
+    public Result<Png> ParseLayer(Stream stream)
+    {
+        var ms = new MemoryStream();
+        stream.CopyTo(ms);
+        ms.Position = 0;
+        return Png.Open(ms);
+    }
+}
+```
+
+### Example implementation (byte array)
+
+```csharp
+public class ByteArrayLayerParser : ILayerParser<byte[]>
+{
+    public Result<byte[]> ParseLayer(Stream stream)
+    {
+        using var ms = new MemoryStream();
+        stream.CopyTo(ms);
+        return ms.ToArray();
+    }
+}
+```

--- a/olve-packages/skills/olve-openraster/references/README.md
+++ b/olve-packages/skills/olve-openraster/references/README.md
@@ -1,0 +1,38 @@
+# Olve.OpenRaster -- Overview
+
+API docs: [https://olivervea.github.io/Olve.Utilities/api/Olve.OpenRaster.html](https://olivervea.github.io/Olve.Utilities/api/Olve.OpenRaster.html)
+
+## What it does
+
+Lightweight, read-only access to [OpenRaster](https://www.openraster.org/) (`.ora`) files in native C#. OpenRaster is a layered image format used by digital painting applications like GIMP and Krita.
+
+## Design philosophy
+
+- **Read-only**: The library parses `.ora` files but does not create or modify them.
+- **No image decoding**: Layer image data is accessed through the `ILayerParser<T>` interface, letting consumers bring their own image library (e.g., BigGustave, SkiaSharp, ImageSharp).
+- **Result-based error handling**: All operations return `Result<T>` from `Olve.Results` instead of throwing exceptions.
+- **Follows the OpenRaster spec**: Models map directly to the [OpenRaster baseline layer stack specification](https://www.openraster.org/baseline/layer-stack-spec.html). Composite operations follow the [W3C Compositing and Blending](https://www.w3.org/TR/compositing-1/) specification.
+- **Bidirectional layer/group relationships**: Layers know which groups they belong to and groups know which layers they contain.
+
+## Package structure
+
+| Namespace | Contents |
+| --- | --- |
+| `Olve.OpenRaster` | Models (`OpenRasterFile`, `Layer`, `Group`, `CompositeOperation`, enums), operations (`ReadOpenRasterFile`, `ReadLayerAs<T>`), and `ILayerParser<T>` interface. |
+| `Olve.OpenRaster.Parsing` | Internal XML and ZIP parsing helpers (not part of the public API). |
+
+## Installation
+
+```bash
+dotnet add package Olve.OpenRaster
+```
+
+## How .ora files work
+
+An `.ora` file is a ZIP archive containing:
+
+- `mimetype` -- must be `image/openraster`
+- `stack.xml` -- XML describing the layer hierarchy, canvas dimensions, and metadata
+- `data/*.png` (or other formats) -- the actual layer image files
+
+The library reads `stack.xml` to build the `OpenRasterFile` model, and can open individual layer entries from the ZIP for custom parsing.

--- a/olve-packages/skills/olve-packages/SKILL.md
+++ b/olve-packages/skills/olve-packages/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: olve-packages
+description: >-
+  Overview of Olve.* shared NuGet packages — what packages exist, their purpose, and how they relate to each other.
+  Use when the user asks about available Olve packages or needs help choosing which package to use.
+user-invocable: false
+---
+
+# Olve Packages
+
+Shared .NET NuGet packages published from [Olve.Utilities](https://github.com/OliverVea/Olve.Utilities). These are building-block libraries used across multiple Olve.* applications (e.g. Olve.Trains, Olve.Pipelines). This is not a complete list of all Olve.* packages — other repositories publish their own.
+
+API docs: https://olivervea.github.io/Olve.Utilities/
+
+## Available Packages
+
+| Package | Purpose |
+|---------|---------|
+| **Olve.Results** | Functional `Result`/`Result<T>` types for non-throwing error handling |
+| **Olve.Results.TUnit** | TUnit assertion extensions for Result types |
+| **Olve.Paths** | Cross-platform path manipulation inspired by Python's pathlib |
+| **Olve.Paths.Glob** | Glob pattern matching extension for Olve.Paths |
+| **Olve.Validation** | Fluent validation framework returning `Result` |
+| **Olve.Utilities** | Meta-package: typed IDs, collections, graphs, pagination, datetime formatting |
+| **Olve.MinimalApi** | ASP.NET Minimal API extensions for Result mapping and validation filters |
+| **Olve.OpenRaster** | Read-only access to OpenRaster (.ora) layered image files |
+| **Olve.TinyEXR** | P/Invoke bindings for tinyexr OpenEXR library |
+
+## Dependency Graph
+
+```
+Olve.Utilities (meta-package)
+├── Olve.Results
+├── Olve.Paths
+│   └── Olve.Paths.Glob (extension)
+└── Olve.Validation (uses Olve.Results)
+
+Olve.MinimalApi
+├── Olve.Results
+├── Olve.Validation
+└── Olve.Paths
+
+Olve.Results.TUnit
+└── Olve.Results
+
+Olve.OpenRaster
+└── Olve.Results
+
+Olve.TinyEXR (standalone, native interop)
+```
+
+## Installation
+
+All packages are available on NuGet:
+
+```bash
+dotnet add package Olve.Results
+dotnet add package Olve.Utilities   # includes Results, Paths, Validation
+```
+
+## Per-Package Reference
+
+Each package has its own skill with full API reference. Use the skill name to access detailed documentation:
+
+- `olve-results` — Result types, Chain, Concat, Map, Bind, error propagation
+- `olve-results-tunit` — TUnit assertions for Result types
+- `olve-paths` — IPath, IPurePath, filesystem operations
+- `olve-paths-glob` — TryGlob extension method
+- `olve-validation` — Fluent validators (string, int, decimal, enumerable)
+- `olve-utilities` — Id\<T\>, collections, graphs, pagination
+- `olve-minimal-api` — Result-to-HTTP mapping, validation filters
+- `olve-openraster` — OpenRaster file reading
+- `olve-tinyexr` — EXR image loading/saving

--- a/olve-packages/skills/olve-paths-glob/SKILL.md
+++ b/olve-packages/skills/olve-paths-glob/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: olve-paths-glob
+description: Glob pattern matching for Olve.Paths — find files matching wildcard patterns within an IPath directory using the TryGlob extension method.
+user-invocable: false
+---
+
+# Olve.Paths.Glob
+
+Glob pattern matching for `IPath` directories. Source: `Olve.Utilities/src/Olve.Paths.Glob/`.
+
+## API
+
+Single extension method in `Olve.Paths.Glob.PathExtensions`:
+
+```csharp
+public static bool TryGlob(
+    this IPath path,
+    string pattern,
+    [NotNullWhen(true)] out IEnumerable<IPath>? matches,
+    bool ignoreCase = false)
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `path` | `IPath` | Root directory to search within. **Must be absolute** — returns `false` if the path is not absolute. |
+| `pattern` | `string` | Glob pattern to match files against. |
+| `matches` | `out IEnumerable<IPath>?` | Matched file paths, each relative to `path` (combined via `path / match`). `null` when the method returns `false`. |
+| `ignoreCase` | `bool` | Case-insensitive matching when `true`. Default: `false`. |
+
+### Returns
+
+`true` if `path` was absolute and matching succeeded (even if zero files matched). `false` if `path` could not be resolved to an absolute path.
+
+## Pattern Syntax
+
+Uses `Microsoft.Extensions.FileSystemGlobbing.Matcher` under the hood.
+
+| Pattern | Matches |
+|---|---|
+| `*.txt` | All `.txt` files in the root directory |
+| `**/*.txt` | All `.txt` files in any subdirectory (recursive) |
+| `src/**/*.cs` | All `.cs` files under `src/` at any depth |
+| `docs/*.md` | All `.md` files directly in `docs/` |
+
+**Hidden file exclusion:** The matcher automatically excludes hidden files and directories (anything matching `**/.*`). This is always applied and cannot be overridden.
+
+## Absolute Path Requirement
+
+The `path` must resolve to an absolute path via `IPath.TryGetAbsolute`. If the path is relative, `TryGlob` returns `false` and `matches` is `null`. Always use absolute `IPath` instances as the root.
+
+## Usage
+
+```csharp
+using Olve.Paths.Glob;
+
+IPath directory = ...; // must be absolute
+
+if (directory.TryGlob("**/*.cs", out var matches))
+{
+    foreach (var match in matches)
+    {
+        // match is an IPath: directory / relative match path
+    }
+}
+
+// Case-insensitive matching
+directory.TryGlob("**/*.TXT", out var files, ignoreCase: true);
+```

--- a/olve-packages/skills/olve-paths/SKILL.md
+++ b/olve-packages/skills/olve-paths/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: olve-paths
+description: Reference for Olve.Paths — cross-platform path manipulation with IPurePath, IPath, Path factory, and filesystem operations. Use when writing or reading code that uses Olve.Paths types.
+user-invocable: false
+---
+
+# Olve.Paths
+
+Cross-platform path manipulation inspired by Python's `pathlib`. Source: `Olve.Utilities/src/Olve.Paths/`.
+
+Reference docs: [README](references/README.md) | [IPurePath](references/IPurePath.md) | [IPath](references/IPath.md) | [Path](references/Path.md) | [Enums](references/Enums.md) | [Extensions](references/Extensions.md)
+
+**Key principle:** Use `IPurePath` for platform-independent path manipulation without filesystem access. Use `IPath` when you need filesystem operations (existence, children, element type).
+
+## Path Creation
+
+```csharp
+// Environment-aware path (uses current OS)
+var path = Path.Create("/home/user/documents");
+
+// Pure path (no filesystem, works on any OS)
+var pure = Path.CreatePure("/home/user/docs", PathPlatform.Unix);
+
+// Temporary paths
+var tempDir = Path.CreateTempDirectory("my-app-");
+var tempFile = Path.CreateTempFile();
+```
+
+## Path Navigation
+
+```csharp
+var path = Path.Create("/home/user/documents");
+
+var parent = path.Parent;           // /home/user
+var name = path.Name;               // documents
+var child = path / "newfile.txt";   // /home/user/documents/newfile.txt
+```
+
+## Filesystem Operations (IPath only)
+
+```csharp
+var exists = path.Exists();
+var elementType = path.ElementType;  // File, Directory, or None
+
+if (path.TryGetChildren(out var children))
+{
+    foreach (var child in children) { /* ... */ }
+}
+
+path.EnsurePathExists();  // creates directory if missing
+```
+
+## Pure Path Platform Targeting
+
+```csharp
+var unix = Path.CreatePure("/home/user", PathPlatform.Unix);
+var win = Path.CreatePure(@"C:\users\user", PathPlatform.Windows);
+
+unix.Platform;  // PathPlatform.Unix
+win.Platform;   // PathPlatform.Windows
+```

--- a/olve-packages/skills/olve-paths/references/Enums.md
+++ b/olve-packages/skills/olve-paths/references/Enums.md
@@ -1,0 +1,39 @@
+# Enums
+
+## PathPlatform
+
+https://olivervea.github.io/Olve.Utilities/api/Olve.Paths.PathPlatform.html
+
+Specifies the platform a path is intended for.
+
+Values:
+- `None` -- no specific platform
+- `Windows` -- Windows-style path (backslash separator, drive letters)
+- `Unix` -- Unix-style path (forward slash separator)
+
+## PathType
+
+https://olivervea.github.io/Olve.Utilities/api/Olve.Paths.PathType.html
+
+Describes the classification of a path string.
+
+Values:
+- `Stub` -- a bare name, not rooted (e.g., `file.txt`, `subdir`)
+- `Relative` -- starts with `.` or `..` (e.g., `./file.txt`, `../parent`)
+- `Absolute` -- rooted path (e.g., `/home/user`, `C:\users\user`)
+
+Behavior during concatenation:
+- **Stub** paths are appended directly to the left path's segments.
+- **Relative** paths are resolved: `..` pops segments from the left path.
+- **Absolute** paths cannot be on the right side of a concatenation (throws `NotSupportedException`).
+
+## ElementType
+
+https://olivervea.github.io/Olve.Utilities/api/Olve.Paths.ElementType.html
+
+Represents the type of a filesystem element.
+
+Values:
+- `None` -- no specific type (path does not exist or type is unknown)
+- `Directory` -- the element is a directory
+- `File` -- the element is a file

--- a/olve-packages/skills/olve-paths/references/Extensions.md
+++ b/olve-packages/skills/olve-paths/references/Extensions.md
@@ -1,0 +1,38 @@
+# Extension Classes
+
+## PathExtensions
+
+https://olivervea.github.io/Olve.Utilities/api/Olve.Paths.PathExtensions.html
+
+Extension methods for `IPath`.
+
+- `bool EnsurePathExists(this IPath path)` -- ensures the directory at the given path exists, creating it if necessary. Returns `true` if the directory was created, `false` if it already existed.
+
+```csharp
+var dir = Path.Create("/home/user/new-dir");
+var created = dir.EnsurePathExists(); // true if it was created
+```
+
+## PurePathMatchExtensions
+
+https://olivervea.github.io/Olve.Utilities/api/Olve.Paths.PurePathMatchExtensions.html
+
+Functional pattern matching on `IPurePath` implementations. Returns a value based on the runtime type.
+
+- `TOut Match<T, TOut>(this IPurePath path, Func<T, TOut> action, Func<TOut> fallback)` -- matches against one type
+- `TOut Match<T1, T2, TOut>(this IPurePath path, Func<T1, TOut> action1, Func<T2, TOut> action2, Func<TOut> fallback)` -- matches against two types
+- `TOut Match<T1, T2, T3, TOut>(this IPurePath path, Func<T1, TOut> action1, Func<T2, TOut> action2, Func<T3, TOut> action3, Func<TOut> fallback)` -- matches against three types
+
+All type parameters are constrained to `IPurePath`. The first matching type wins; `fallback` is called if none match.
+
+## PurePathSwitchExtensions
+
+https://olivervea.github.io/Olve.Utilities/api/Olve.Paths.PurePathSwitchExtensions.html
+
+Functional switch (void-returning) on `IPurePath` implementations. Executes an action based on the runtime type.
+
+- `void Switch<T>(this IPurePath path, Action<T> action, Action? fallback = null)` -- switches on one type
+- `void Switch<T1, T2>(this IPurePath path, Action<T1> action1, Action<T2> action2, Action? fallback = null)` -- switches on two types
+- `void Switch<T1, T2, T3>(this IPurePath path, Action<T1> action1, Action<T2> action2, Action<T3> action3, Action? fallback = null)` -- switches on three types
+
+All type parameters are constrained to `IPurePath`. The first matching type wins; `fallback` is called if none match.

--- a/olve-packages/skills/olve-paths/references/IPath.md
+++ b/olve-packages/skills/olve-paths/references/IPath.md
@@ -1,0 +1,56 @@
+# IPath
+
+https://olivervea.github.io/Olve.Utilities/api/Olve.Paths.IPath.html
+
+Interface. Extends `IPurePath` with environment-aware filesystem operations.
+
+Inherited from IPurePath:
+- `string Path`
+- `PathPlatform Platform`
+- `PathType Type`
+- `string? Name`
+- `IPurePath ParentPure`
+- `bool TryGetParentPure(out IPurePath? parent)`
+- `bool TryGetName(out string? fileName)`
+- `IPurePath Append(IPurePath right)`
+- `IPurePath Append(string right)`
+
+Properties:
+- `ElementType ElementType` -- type of the filesystem element (File, Directory, or None); throws `InvalidOperationException` if undetermined
+- `IPath Absolute` -- absolute version of the path; throws `InvalidOperationException` if unavailable
+- `IPath Parent` -- parent as IPath; throws `InvalidOperationException` if no parent
+- `IEnumerable<IPath> Children` -- child elements; throws `InvalidOperationException` if no children
+
+Methods:
+- `bool TryGetElementType(out ElementType type)` -- attempts to determine the filesystem element type
+- `bool TryGetAbsolute(out IPath? absolute)` -- attempts to resolve the absolute path
+- `bool TryGetParent(out IPath? parent)` -- attempts to retrieve the parent as IPath
+- `bool TryGetChildren(out IEnumerable<IPath>? children)` -- attempts to retrieve child elements (directories and files)
+- `IPath AppendPath(IPurePath right)` -- appends a pure path, returns IPath
+- `IPath AppendPath(string right)` -- appends a string segment, returns IPath
+- `bool Exists()` -- checks whether the path exists on the filesystem
+- `string GetLinkString(int? lineNumber = null, int? columnNumber = null)` -- returns a clickable link string (e.g., `file:///path:line:col`)
+
+Operators:
+- `IPath operator /(IPath left, IPurePath right)` -- concatenates via AppendPath
+- `IPath operator /(IPath left, string right)` -- concatenates via AppendPath
+
+## Usage
+
+```csharp
+var path = Path.Create("/home/user/documents");
+
+path.Exists();       // true/false
+path.ElementType;    // ElementType.Directory
+path.Parent;         // IPath for "/home/user"
+
+var child = path / "file.txt";
+child.Exists();      // check filesystem
+
+if (path.TryGetChildren(out var children))
+{
+    foreach (var c in children) { /* ... */ }
+}
+
+path.TryGetAbsolute(out var abs);  // resolve relative to absolute
+```

--- a/olve-packages/skills/olve-paths/references/IPurePath.md
+++ b/olve-packages/skills/olve-paths/references/IPurePath.md
@@ -1,0 +1,42 @@
+# IPurePath
+
+https://olivervea.github.io/Olve.Utilities/api/Olve.Paths.IPurePath.html
+
+Interface. Immutable, pure file system path independent of the actual filesystem. No disk access.
+
+Properties:
+- `string Path` -- string representation of the path
+- `PathPlatform Platform` -- platform of the path (Unix or Windows)
+- `PathType Type` -- path classification (Absolute, Relative, or Stub)
+- `string? Name` -- name of the last path component (filename or directory name), or null if unavailable
+- `IPurePath ParentPure` -- parent path; throws `InvalidOperationException` if no parent
+
+Methods:
+- `bool TryGetParentPure(out IPurePath? parent)` -- attempts to retrieve the parent path
+- `bool TryGetName(out string? fileName)` -- attempts to retrieve the name of the path component
+- `IPurePath Append(IPurePath right)` -- appends another pure path
+- `IPurePath Append(string right)` -- appends a string segment (must be a stub, not absolute or relative)
+
+Operators:
+- `IPurePath operator /(IPurePath left, IPurePath right)` -- concatenates two pure paths
+- `IPurePath operator /(IPurePath left, string right)` -- concatenates a path with a string segment
+
+## Path Types
+
+- **Absolute** -- rooted path (e.g., `/home/user` or `C:\users\user`)
+- **Relative** -- starts with `.` or `..`, resolved during concatenation
+- **Stub** -- bare name like `file.txt` or `subdir`, appended directly
+
+## Usage
+
+```csharp
+var path = Path.CreatePure("/home/user/docs", PathPlatform.Unix);
+
+path.Path;       // "/home/user/docs"
+path.Platform;   // PathPlatform.Unix
+path.Type;       // PathType.Absolute
+path.Name;       // "docs"
+path.ParentPure; // IPurePath for "/home/user"
+
+var joined = path / "readme.txt";  // "/home/user/docs/readme.txt"
+```

--- a/olve-packages/skills/olve-paths/references/Path.md
+++ b/olve-packages/skills/olve-paths/references/Path.md
@@ -1,0 +1,59 @@
+# Path
+
+https://olivervea.github.io/Olve.Utilities/api/Olve.Paths.Path.html
+
+Static class. Factory for creating `IPurePath` and `IPath` instances.
+
+## Pure Path Creation
+
+- `IPurePath CreatePure(string path)` -- creates a pure path using the current OS platform
+- `IPurePath CreatePure(string path, PathPlatform platform)` -- creates a pure path for a specific platform
+
+## Path Creation
+
+- `IPath Create(string path, IPathEnvironment? pathEnvironment = null)` -- creates an environment-aware path using the current OS platform
+- `IPath Create(string path, PathPlatform platform, IPathEnvironment? pathEnvironment = null)` -- creates an environment-aware path for a specific platform
+
+## Assembly and Directory Paths
+
+- `bool TryGetAssemblyExecutable(out IPath? path, IPathEnvironment? pathEnvironment = null)` -- attempts to get the current assembly's executable path
+- `bool TryGetAssemblyExecutablePure(out IPurePath? purePath, IPathEnvironment? pathEnvironment = null)` -- attempts to get the assembly executable as a pure path
+- `IPurePath GetCurrentDirectoryPure()` -- current working directory as IPurePath
+- `IPath GetCurrentDirectory()` -- current working directory as IPath
+- `IPurePath GetHomeDirectoryPure()` -- user's home directory as IPurePath (reads HOME env var)
+- `IPath GetHomeDirectory()` -- user's home directory as IPath (reads HOME env var)
+
+## Temporary Paths
+
+- `IPath GetTempDirectory()` -- system temp directory
+- `IPath CreateTempDirectory(string? prefix = null)` -- creates a unique temp subdirectory
+- `IPath CreateTempFile()` -- creates a unique zero-byte temp file
+
+## Behavior Notes
+
+- On unsupported platforms, returns `UnsupportedPath`/`UnsupportedPurePath` which throw `PlatformNotSupportedException` on any access.
+- When the path string points to an existing directory, a trailing separator is appended automatically.
+- Windows paths normalize forward slashes to backslashes.
+- `IPathEnvironment` can be injected for testing (provides current directory and assembly executable path).
+
+## Usage
+
+```csharp
+// Auto-detect platform
+var path = Path.Create("/home/user/docs");
+var pure = Path.CreatePure("/home/user/docs");
+
+// Explicit platform
+var unix = Path.CreatePure("/home/user", PathPlatform.Unix);
+var win = Path.CreatePure(@"C:\users\user", PathPlatform.Windows);
+
+// Temp paths
+var tmpDir = Path.CreateTempDirectory("my-app-");
+var tmpFile = Path.CreateTempFile();
+
+// Assembly path
+if (Path.TryGetAssemblyExecutable(out var exe))
+{
+    var binDir = exe.Parent;
+}
+```

--- a/olve-packages/skills/olve-paths/references/README.md
+++ b/olve-packages/skills/olve-paths/references/README.md
@@ -1,0 +1,28 @@
+# Olve.Paths
+
+Source: https://olivervea.github.io/Olve.Utilities/src/Olve.Paths/README.html
+
+A .NET library for working with file and directory paths inspired by Python's `pathlib` module. Provides an object-oriented interface for manipulating paths instead of raw strings.
+
+## Key Types
+
+- **IPurePath** -- Immutable, pure path independent of the filesystem. Platform-aware but does not touch disk.
+- **IPath** -- Extends IPurePath with environment-aware filesystem operations (existence, children, element type).
+- **Path** -- Static factory class for creating IPurePath and IPath instances.
+- **PathPlatform** -- Platform discriminator: `Unix` or `Windows`.
+- **PathType** -- Path classification: `Absolute`, `Relative`, or `Stub`.
+- **ElementType** -- Filesystem element type: `File`, `Directory`, or `None`.
+
+## Primary Usage Patterns
+
+**Path navigation:** Create paths with `Path.Create()` or `Path.CreatePure()`, navigate with `Parent`, `Name`, and the `/` operator for joining segments.
+
+**Pure manipulation:** `Path.CreatePure()` with an explicit `PathPlatform` creates paths that work on any host OS without filesystem access.
+
+**Filesystem queries:** `IPath` supports `Exists()`, `ElementType`, `TryGetChildren()`, `TryGetAbsolute()`, and `EnsurePathExists()`.
+
+**Temporary paths:** `Path.GetTempDirectory()`, `Path.CreateTempDirectory()`, and `Path.CreateTempFile()` wrap .NET temp APIs and return `IPath`.
+
+## Design Philosophy
+
+Separation between pure path manipulation (no side effects, cross-platform) and environment-aware paths (filesystem access). The `/` operator provides intuitive path joining. All implementations are internal; consumers work through `IPurePath` and `IPath` interfaces. Platform detection is automatic when no `PathPlatform` is specified. Stub paths (bare names like `file.txt`) can be appended; relative paths (starting with `.` or `..`) are resolved during concatenation.

--- a/olve-packages/skills/olve-results-tunit/SKILL.md
+++ b/olve-packages/skills/olve-results-tunit/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: olve-results-tunit
+description: TUnit assertion extensions for Olve.Results Result and Result<T> types. Use when writing tests that verify Result success/failure states and their values or problems.
+user-invocable: false
+---
+
+# Olve.Results.TUnit
+
+TUnit assertion extensions for `Result` and `Result<T>`. Source: `Olve.Utilities/src/Olve.Results.TUnit/`.
+
+All methods are extension methods on `IAssertionSource<Result>` or `IAssertionSource<Result<T>>`, used inside `await Assert.That(...)`.
+
+## API Reference
+
+### Succeeded
+
+Asserts the result represents success.
+
+```csharp
+// Result<T>
+PropertyAssertionResult<Result<T>> Succeeded<T>(this IAssertionSource<Result<T>> source)
+
+// Result (valueless)
+PropertyAssertionResult<Result> Succeeded(this IAssertionSource<Result> source)
+```
+
+```csharp
+Result<int> result = 42;
+await Assert.That(result).Succeeded();
+
+Result empty = Result.Success();
+await Assert.That(empty).Succeeded();
+```
+
+### Failed
+
+Asserts the result represents failure.
+
+```csharp
+// Result<T>
+PropertyAssertionResult<Result<T>> Failed<T>(this IAssertionSource<Result<T>> source)
+
+// Result (valueless)
+PropertyAssertionResult<Result> Failed(this IAssertionSource<Result> source)
+```
+
+```csharp
+Result<int> result = new ResultProblem("Not found");
+await Assert.That(result).Failed();
+
+Result empty = new ResultProblem("Something went wrong");
+await Assert.That(empty).Failed();
+```
+
+### SucceededAndValue
+
+Asserts the result succeeded and runs a nested assertion against the unwrapped value. Only available for `Result<T>`.
+
+```csharp
+MemberAssertionResult<Result<T>> SucceededAndValue<T>(this IAssertionSource<Result<T>> source,
+    Func<IAssertionSource<T>, object> assertion)
+```
+
+```csharp
+Result<int> result = 42;
+await Assert.That(result).SucceededAndValue(v => v.IsEqualTo(42));
+
+Result<string> nameResult = "Alice";
+await Assert.That(nameResult).SucceededAndValue(v => v.IsEqualTo("Alice"));
+```
+
+### FailedAndProblemCollection
+
+Asserts the result failed and runs a nested assertion against the `ResultProblemCollection`.
+
+```csharp
+// Result<T>
+MemberAssertionResult<Result<T>> FailedAndProblemCollection<T>(this IAssertionSource<Result<T>> source,
+    Func<IAssertionSource<ResultProblemCollection>, object> assertion)
+
+// Result (valueless)
+MemberAssertionResult<Result> FailedAndProblemCollection<TAssertion>(this IAssertionSource<Result> source,
+    Func<IAssertionSource<ResultProblemCollection>, TAssertion> assertion)
+    where TAssertion : Assertion<ResultProblemCollection>
+```
+
+```csharp
+Result<int> result = new ResultProblem("Not found");
+await Assert.That(result).FailedAndProblemCollection(p => p.IsNotEmpty());
+
+Result empty = new ResultProblem("Bad request");
+await Assert.That(empty).FailedAndProblemCollection(p => p.IsNotEmpty());
+```

--- a/olve-packages/skills/olve-results/SKILL.md
+++ b/olve-packages/skills/olve-results/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: olve-results
+description: Reference for Olve.Results — Result/Result<T>, TryPickProblems, ResultProblem, DeletionResult, Chain/Concat/Map/Bind composition, and error propagation with Prepend. Use when writing or reading code that uses the Result pattern.
+user-invocable: false
+---
+
+# Olve.Results
+
+Error handling via `Result` types. Source: `Olve.Utilities/src/Olve.Results/`.
+
+Reference docs: [README](references/README.md) | [Result](references/Result.md) | [Result\<T\>](references/Result_T.md) | [ResultProblem](references/ResultProblem.md) | [ResultProblemCollection](references/ResultProblemCollection.md) | [DeletionResult](references/DeletionResult.md) | [Extensions](references/Extensions.md)
+
+**Golden rule:** Always use `TryPickProblems`, never `.Failed`/`.Succeeded`/`.Value` directly.
+
+## Result (valueless)
+
+```csharp
+// Success
+return Result.Success();
+
+// Failure — implicit conversion from ResultProblem
+return new ResultProblem("Something failed");
+
+// Check
+if (DoSomething().TryPickProblems(out var problems))
+{
+    return problems.Prepend("Context about what failed");
+}
+```
+
+## Result\<T\> (valued)
+
+```csharp
+// Success — implicit conversion from T
+return myValue;
+
+// Failure
+return new ResultProblem("Not found: '{0}'", id);
+
+// Check — value is safe to use after the if block
+if (GetValue().TryPickProblems(out var problems, out var value))
+{
+    return problems;
+}
+// use value here
+```
+
+## ResultProblem
+
+**Use format strings with `{0}`, `{1}` — NOT string interpolation:**
+
+```csharp
+// Correct
+return new ResultProblem("Failed to parse '{0}' as {1}", input, typeName);
+
+// WRONG — loses structured args
+return new ResultProblem($"Failed to parse '{input}'");
+
+// With exception
+return new ResultProblem(exception, "Failed to read '{0}'", path);
+```
+
+Implicit conversion: `ResultProblem` converts directly to `Result`, `Result<T>`, or `DeletionResult`.
+
+## DeletionResult
+
+Three states for delete operations:
+
+```csharp
+return DeletionResult.Success();    // deleted
+return DeletionResult.NotFound();   // entity didn't exist
+return DeletionResult.Error(problems);  // something went wrong
+```
+
+```csharp
+// Check
+if (result.TryPickProblems(out var problems)) { ... }  // true on error only
+if (result.WasNotFound) { ... }
+
+// Convert to Result (not-found treated as success by default)
+Result asResult = deletionResult.MapToResult();
+
+// Pattern match
+string msg = deletionResult.Match(
+    onSuccess: () => "Deleted",
+    onNotFound: () => "Already gone",
+    onProblems: p => p.First().ToBriefString());
+```
+
+## Composition
+
+### Chain — sequential dependent steps, short-circuits on first failure
+
+```csharp
+// Valueless
+Result.Chain(() => Step1(), () => Step2());
+
+// With values — each step receives the previous value
+Result<T2> result = Result.Chain(
+    () => GetA(),       // Result<T1>
+    a => Process(a));   // T1 -> Result<T2>
+
+// Up to 4 steps
+Result<T3> result = Result.Chain(
+    () => GetA(), a => GetB(a), b => GetC(b));
+```
+
+### Concat — independent steps, aggregates all problems
+
+```csharp
+// Valueless — runs all, collects all errors
+Result.Concat(() => Validate1(), () => Validate2(), () => Validate3());
+
+// With values — returns tuple on success
+Result<(string, int)> = Result.Concat(
+    () => LoadUser(), () => LoadSettings());
+
+// Direct Result<T> overloads (no Func wrapper)
+Result<(T1, T2)> = Result.Concat(resultA, resultB);
+```
+
+### Map — transform value (non-Result function)
+
+```csharp
+Result<int> length = GetString().Map(s => s.Length);
+```
+
+### Bind — transform value (Result-returning function)
+
+```csharp
+Result<int> parsed = GetString().Bind(s =>
+    int.TryParse(s, out var n)
+        ? Result.Success(n)
+        : new ResultProblem("Invalid int: '{0}'", s));
+```
+
+### ToEmptyResult — discard value
+
+```csharp
+Result empty = GetValue().ToEmptyResult();  // Result<T> -> Result
+```
+
+### WithValueOnSuccess — attach value
+
+```csharp
+Result<int> valued = someResult.WithValueOnSuccess(42);  // Result -> Result<T>
+```
+
+## Error Context with Prepend
+
+Build hierarchical error traces by prepending context as errors propagate up:
+
+```csharp
+if (LoadMesh(path).TryPickProblems(out var problems, out var mesh))
+{
+    return problems.Prepend("Failed to load building mesh for collision");
+}
+
+// Result is: "Failed to load building mesh for collision" -> "File not found: '{0}'"
+```
+
+## Collection Extensions
+
+```csharp
+IEnumerable<Result<T>> results = items.Select(Process);
+
+// Aggregate — true if any failed, collects all problems + all values
+if (results.TryPickProblems(out var problems, out var values))
+{
+    return problems;
+}
+```
+
+## Dictionary Extensions
+
+```csharp
+var setResult = dictionary.SetWithResult("key", value);  // fails if key exists
+var getResult = readOnlyDict.GetWithResult("key");        // fails if key missing
+```
+
+## Result.Try — exception wrapping
+
+```csharp
+Result<string> text = Result.Try<string, IOException>(
+    () => File.ReadAllText(path),
+    "Error reading config file");
+
+Result voidResult = Result.Try<IOException>(
+    () => File.Delete(path),
+    "Error deleting file");
+```
+
+## ResultFuncExtensions
+
+```csharp
+// Convert Action<T> to Func<T, Result>
+Func<T, Result> func = myAction.ToResultFunc();
+```

--- a/olve-packages/skills/olve-results/references/DeletionResult.md
+++ b/olve-packages/skills/olve-results/references/DeletionResult.md
@@ -1,0 +1,25 @@
+# DeletionResult
+
+https://olivervea.github.io/Olve.Utilities/api/Olve.Results.DeletionResult.html
+
+Readonly struct. Three-state result for deletion operations: success, not found, or error.
+
+Properties:
+- `bool Succeeded` — deletion succeeded
+- `bool Failed` — not-found or error
+- `bool WasNotFound` — entity was not found
+- `ResultProblemCollection? Problems` — null unless error
+
+Static methods:
+- `DeletionResult Success()` — successful deletion
+- `DeletionResult NotFound()` — entity not found
+- `DeletionResult Error(params IEnumerable<ResultProblem> problems)` — deletion failed
+
+Instance methods:
+- `bool TryPickProblems(out ResultProblemCollection? problems)` — true if error state
+
+Implicit conversions: `ResultProblem` -> `DeletionResult` (error), `ResultProblemCollection` -> `DeletionResult` (error)
+
+Extension methods (DeletionResultExtensions):
+- `Result MapToResult(bool allowNotFound = true)` — converts to Result. Not-found treated as success by default.
+- `T Match<T>(Func<T> onSuccess, Func<T> onNotFound, Func<ResultProblemCollection, T> onProblems)` — exhaustive pattern match

--- a/olve-packages/skills/olve-results/references/Extensions.md
+++ b/olve-packages/skills/olve-results/references/Extensions.md
@@ -1,0 +1,39 @@
+# Result Extension Classes
+
+## ResultExtensions
+
+https://olivervea.github.io/Olve.Utilities/api/Olve.Results.ResultExtensions.html
+
+- `Result ToEmptyResult<T>(this Result<T> result)` — discard value, keep success/failure
+- `Result<TDest> Map<TSource, TDest>(this Result<TSource> result, Func<TSource, TDest> map)` — transform value. Returns original problems on failure.
+- `Result<TDest> Bind<TSource, TDest>(this Result<TSource> result, Func<TSource, Result<TDest>> bind)` — transform with Result-returning func. Returns original problems on failure.
+- `Result<T> WithValueOnSuccess<T>(this Result result, T value)` — attach value to successful Result
+
+## ResultEnumerableExtensions
+
+https://olivervea.github.io/Olve.Utilities/api/Olve.Results.ResultEnumerableExtensions.html
+
+IEnumerable\<Result\>:
+- `bool TryPickProblems(out ResultProblemCollection? problems)` — true if any failed, aggregates all
+- `bool HasProblems()` — true if any failed
+- `IEnumerable<ResultProblem> GetProblems()` — flattens all problems
+
+IEnumerable\<Result\<T\>\>:
+- `bool TryPickProblems(out ResultProblemCollection? problems)` — true if any failed, aggregates all
+- `bool TryPickProblems(out ResultProblemCollection? problems, out IList<T> values)` — true if any failed, populates both
+- `bool HasProblems()` — true if any failed
+- `IEnumerable<T> GetValues()` — successful values only
+- `IEnumerable<ResultProblem> GetProblems()` — flattens all problems
+
+## DictionaryResultExtensions
+
+https://olivervea.github.io/Olve.Utilities/api/Olve.Results.DictionaryResultExtensions.html
+
+- `Result SetWithResult<TKey, TValue>(this IDictionary<TKey, TValue> dict, TKey key, TValue value)` — fails if key exists
+- `Result<TValue> GetWithResult<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dict, TKey key)` — fails if key missing
+
+## ResultFuncExtensions
+
+https://olivervea.github.io/Olve.Utilities/api/Olve.Results.ResultFuncExtensions.html
+
+- `Func<T, Result> ToResultFunc<T>(this Action<T> action)` — converts an Action\<T\> to a Func\<T, Result\> that always returns success

--- a/olve-packages/skills/olve-results/references/README.md
+++ b/olve-packages/skills/olve-results/references/README.md
@@ -1,0 +1,35 @@
+# Olve.Results
+
+Source: https://olivervea.github.io/Olve.Utilities/src/Olve.Results/README.html
+
+A lightweight, functional result type for structured, non-throwing error handling in .NET. APIs return `Result` or `Result<T>` representing either success or a collection of `ResultProblem`s.
+
+## Key Types
+
+- **Result** — Represents success or problems.
+- **Result\<T\>** — Success with a value or problems.
+- **DeletionResult** — Three-state result (success, not found, or error).
+- **ResultProblem** — Individual problem with message, exception, metadata, and origin info.
+- **ResultProblemCollection** — Immutable collection supporting merge, prepend, and append operations.
+
+## Primary Usage Patterns
+
+**Exception conversion:** `Result.Try()` wraps operations to convert exceptions into `ResultProblem`s instead of throwing.
+
+**Chaining:** `Result.Chain()` executes dependent steps where the second depends on the first's success.
+
+**Combining:** `Result.Concat()` runs independent operations and aggregates all problems.
+
+**Context building:** Problems can have higher-level context prepended as they propagate upward.
+
+**Validation:** Return `Result` from validation routines to make checks composable.
+
+## Notable Features
+
+The library automatically captures origin information (file and line number) for debugging without throwing exceptions. Functional extensions like `Map` and `Bind` enable value transformations. Dictionary extensions (`SetWithResult`, `GetWithResult`) wrap dictionary operations as results.
+
+Performance-oriented code can use `Try*` methods following a pattern that avoids allocations entirely.
+
+## Design Philosophy
+
+Explicit success/failure flow without exceptions. Immutable, structured problems with optional metadata. Trade-offs include slight performance overhead from struct wrapping and generic `ResultProblem` types rather than typed errors.

--- a/olve-packages/skills/olve-results/references/Result.md
+++ b/olve-packages/skills/olve-results/references/Result.md
@@ -1,0 +1,37 @@
+# Result
+
+https://olivervea.github.io/Olve.Utilities/api/Olve.Results.Result.html
+
+Readonly struct. Success or failure without a value.
+
+Properties:
+- `bool Succeeded`
+- `bool Failed`
+- `ResultProblemCollection? Problems`
+
+Static methods:
+- `Result Success()`
+- `Result<T> Success<T>(T value)`
+- `Result Failure(params IEnumerable<ResultProblem> problems)`
+- `Result<T> Failure<T>(params IEnumerable<ResultProblem> problems)`
+- `Result Try<TException>(Action action, string? message = null, params object[] args)` — catches TException, returns as problems
+- `Result<TValue> Try<TValue, TException>(Func<TValue> action, string? message = null, params object[] args)`
+
+Chain (sequential dependent steps, stops on first failure):
+- `Result Chain(params IEnumerable<Func<Result>> links)`
+- `Result<T2> Chain<T1, T2>(Func<Result<T1>>, Func<T1, Result<T2>>)`
+- `Result<T3> Chain<T1, T2, T3>(...)`
+- `Result<T4> Chain<T1, T2, T3, T4>(...)`
+
+Concat (independent steps, aggregates all problems):
+- `Result Concat(params IEnumerable<Func<Result>> elements)`
+- `Result Concat(params IEnumerable<Result> results)`
+- `Result<(T1, T2)> Concat<T1, T2>(...)` through `Result<(T1..T6)> Concat<T1..T6>(...)`
+- Both direct `Result<T>` and `Func<Result<T>>` overloads for each arity (2 through 6).
+
+Instance methods:
+- `bool TryPickProblems(out ResultProblemCollection? problems)` — true if failed
+- `Result IfProblem(Action<ResultProblemCollection> action)` — execute on failure, returns self
+- `string ToString()` — returns "Success" or "Failure"
+
+Implicit conversions: `ResultProblem` -> `Result`, `ResultProblemCollection` -> `Result`

--- a/olve-packages/skills/olve-results/references/ResultProblem.md
+++ b/olve-packages/skills/olve-results/references/ResultProblem.md
@@ -1,0 +1,33 @@
+# ResultProblem
+
+https://olivervea.github.io/Olve.Utilities/api/Olve.Results.ResultProblem.html
+
+Class. Represents a problem encountered during an operation.
+
+Constructors:
+- `ResultProblem(string message, params object[] args)` — message: format string. args: format arguments.
+- `ResultProblem(Exception exception, string message, params object[] args)` — exception: causing exception.
+
+Static fields:
+- `string? DefaultSource` — default source for new problems
+- `string[] DefaultTags` — default tags for new problems
+- `int DefaultSeverity` — default severity for new problems
+- `bool DefaultPrintDebug` — controls ToString() format
+
+Properties:
+- `string Message` — raw format string
+- `object[] Args` — format arguments
+- `string[] Tags` — categorization tags (init-settable)
+- `int Severity` — severity level, higher = more severe (init-settable)
+- `string? Source` — problem source (init-settable)
+- `Exception? Exception` — causing exception
+- `ProblemOriginInformation OriginInformation` — auto-captured file/line
+
+Methods:
+- `string ToString()` — uses ToDebugString() if DefaultPrintDebug, else ToBriefString()
+- `string ToBriefString()` — formatted message, omits code locations. Includes exception type and message if present.
+- `string ToDebugString()` — includes code location as clickable link prefix
+
+ProblemOriginInformation:
+- `readonly record struct ProblemOriginInformation(IPath FilePath, int LineNumber)`
+- `string LinkString` — clickable link string for the current platform

--- a/olve-packages/skills/olve-results/references/ResultProblemCollection.md
+++ b/olve-packages/skills/olve-results/references/ResultProblemCollection.md
@@ -1,0 +1,16 @@
+# ResultProblemCollection
+
+https://olivervea.github.io/Olve.Utilities/api/Olve.Results.ResultProblemCollection.html
+
+Class. Immutable collection of ResultProblem. Implements `IEnumerable<ResultProblem>`.
+
+Constructor:
+- `ResultProblemCollection(params IEnumerable<ResultProblem> problems)`
+
+Methods:
+- `IEnumerator<ResultProblem> GetEnumerator()`
+- `ResultProblemCollection Append(params IEnumerable<ResultProblem> resultProblems)` — returns new collection with problems appended
+- `ResultProblemCollection Prepend(params IEnumerable<ResultProblem> resultProblems)` — returns new collection with problems prepended
+- `ResultProblemCollection Prepend(string message, params object[] args)` — creates and prepends a formatted problem
+- `ResultProblemCollection Prepend(Exception exception, string message, params object[] args)` — creates and prepends a problem from an exception
+- `static ResultProblemCollection Merge(params IEnumerable<ResultProblemCollection> problemCollections)` — merges multiple collections into one

--- a/olve-packages/skills/olve-results/references/Result_T.md
+++ b/olve-packages/skills/olve-results/references/Result_T.md
@@ -1,0 +1,29 @@
+# Result\<T\>
+
+https://olivervea.github.io/Olve.Utilities/api/Olve.Results.Result-1.html
+
+Readonly struct. Success with a value or failure.
+
+Properties:
+- `bool Succeeded`
+- `bool Failed`
+- `T? Value`
+- `ResultProblemCollection? Problems`
+
+Instance methods:
+- `bool TryPickProblems(out ResultProblemCollection? problems)` — true if failed
+- `bool TryPickProblems(out ResultProblemCollection? problems, out T? value)` — true if failed; always populates both
+- `bool TryPickValue(out T? value)` — true if succeeded
+- `bool TryPickValue(out T? value, out ResultProblemCollection? problems)` — true if succeeded; always populates both
+- `T GetValueOrDefault(T defaultValue)`
+- `bool TryGetValueOrDefault(out T? value, T defaultValue)`
+- `Result<T> IfProblem(Action<ResultProblemCollection> action)` — execute on failure, returns self
+- `string ToString()` — returns "Success({value})" or "Failure"
+
+Implicit conversions: `T` -> `Result<T>`, `ResultProblem` -> `Result<T>`, `ResultProblemCollection` -> `Result<T>`
+
+Extension methods:
+- `Result<TDest> Map<TDest>(Func<T, TDest> map)` — transform value. Returns original problems on failure.
+- `Result<TDest> Bind<TDest>(Func<T, Result<TDest>> bind)` — transform with Result-returning func. Returns original problems on failure.
+- `Result ToEmptyResult()` — discard value, keep success/failure.
+- `Result<T> WithValueOnSuccess<T>(this Result result, T value)` — attach value to a successful valueless Result.

--- a/olve-packages/skills/olve-tinyexr/SKILL.md
+++ b/olve-packages/skills/olve-tinyexr/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: olve-tinyexr
+description: Reference for Olve.TinyEXR — P/Invoke bindings for the tinyexr EXR image library. Covers loading, saving, validating, and inspecting OpenEXR images via the TinyExr static class. Use when writing or reading code that works with EXR files.
+user-invocable: false
+---
+
+# Olve.TinyEXR
+
+P/Invoke bindings for [tinyexr](https://github.com/syoyo/tinyexr). Source: `Olve.Utilities/src/Olve.TinyEXR/`.
+
+Reference docs: [README](references/README.md) | [TinyExr](references/TinyExr.md) | [Types](references/Types.md)
+
+**Golden rule:** All `TinyExr` methods require `unsafe` context. Always free native pointers with `FreeImageData` or `FreeMemoryBuffer` when done.
+
+## Save and load an EXR file
+
+```csharp
+unsafe
+{
+    var pixels = new float[] { 1.0f, 0.5f, 0.0f, 1.0f }; // Single RGBA pixel
+
+    TinyExr.SaveEXR(pixels, 1, 1, 4, false, "image.exr"); // Save as 32-bit float EXR
+
+    var loaded = TinyExr.LoadEXR("image.exr", out var width, out var height, out var ptr);
+    // loaded is ReadOnlySpan<float> of length width * height * 4
+
+    var r = loaded[0]; // 1.0
+    var g = loaded[1]; // 0.5
+
+    TinyExr.FreeImageData(ptr); // MUST free native memory
+}
+```
+
+## Load from memory
+
+```csharp
+unsafe
+{
+    var bytes = File.ReadAllBytes("image.exr");
+
+    var isExr = TinyExr.IsEXRFromMemory(bytes); // true
+    var loaded = TinyExr.LoadEXRFromMemory(bytes, out var width, out var height, out var ptr);
+
+    TinyExr.FreeImageData(ptr);
+}
+```
+
+## Save to memory
+
+```csharp
+unsafe
+{
+    var pixels = new float[] { 1.0f, 0.0f, 0.0f, 1.0f };
+    var data = TinyExr.SaveEXRToMemory(pixels, 1, 1, 4, false, out var ptr);
+    // data is ReadOnlySpan<byte>
+
+    TinyExr.FreeMemoryBuffer(ptr); // MUST free native memory
+}
+```
+
+## Validate and inspect
+
+```csharp
+var isExr = TinyExr.IsEXR("image.exr"); // true/false
+var version = TinyExr.ParseEXRVersionFromFile("image.exr");
+// version.version == 2, version.tiled, version.multipart, etc.
+```
+
+## Memory management
+
+- `LoadEXR`, `LoadEXRWithLayer`, `LoadEXRFromMemory` return a `float*` via `out` parameter. Free with `TinyExr.FreeImageData(ptr)`.
+- `SaveEXRToMemory` returns a `byte*` via `out` parameter. Free with `TinyExr.FreeMemoryBuffer(ptr)`.
+- Failing to free causes native memory leaks.
+
+## Error handling
+
+All methods throw `TinyExrException` on failure. The exception carries the native error code (`Code`) and message.
+
+```csharp
+try
+{
+    unsafe { TinyExr.LoadEXR("missing.exr", out _, out _, out _); }
+}
+catch (TinyExrException ex)
+{
+    // ex.Code == -7 (TINYEXR_ERROR_CANT_OPEN_FILE)
+    // ex.Message contains the native error description
+}
+```

--- a/olve-packages/skills/olve-tinyexr/references/README.md
+++ b/olve-packages/skills/olve-tinyexr/references/README.md
@@ -1,0 +1,36 @@
+# Olve.TinyEXR — Overview
+
+API docs: [https://olivervea.github.io/Olve.Utilities/api/Olve.TinyEXR.html](https://olivervea.github.io/Olve.Utilities/api/Olve.TinyEXR.html)
+
+.NET P/Invoke bindings for [tinyexr](https://github.com/syoyo/tinyexr), a small library for reading and writing OpenEXR images.
+
+## Installation
+
+```bash
+dotnet add package Olve.TinyEXR
+```
+
+## Public API surface
+
+| Type | Description |
+| --- | --- |
+| `TinyExr` | Static class with safe managed wrappers for loading, saving, and validating EXR images. |
+| `TinyExrException` | Exception thrown on native library errors, carrying the error code and message. |
+| `EXRVersion` | Parsed EXR version header struct (version number, tiled, multipart flags). |
+
+## Platform support
+
+Prebuilt native libraries are included for:
+
+- **win-x64** — `runtimes/win-x64/native/tinyexr.dll`
+- **linux-x64** — `runtimes/linux-x64/native/libtinyexr.so`
+
+Cross-platform builds for osx-x64 and osx-arm64 are planned.
+
+## Unsafe context requirement
+
+All methods on `TinyExr` require an `unsafe` context because they work with native pointers (`float*`, `byte*`). The project or calling code must enable `<AllowUnsafeBlocks>true</AllowUnsafeBlocks>`.
+
+## Native library resolution
+
+The `NativeMethods` class includes a custom `DllImportResolver` that looks for the native library in the `runtimes/{rid}/native/` directory next to the assembly. If not found there, it falls back to default OS resolution.

--- a/olve-packages/skills/olve-tinyexr/references/TinyExr.md
+++ b/olve-packages/skills/olve-tinyexr/references/TinyExr.md
@@ -1,0 +1,141 @@
+# TinyExr
+
+API docs: [https://olivervea.github.io/Olve.Utilities/api/Olve.TinyEXR.TinyExr.html](https://olivervea.github.io/Olve.Utilities/api/Olve.TinyEXR.TinyExr.html)
+
+Static class providing safe managed wrappers over the tinyexr native library. All methods require `unsafe` context.
+
+**Namespace:** `Olve.TinyEXR`
+
+## Loading
+
+### LoadEXR
+
+Loads an EXR image from a file. Returns pixel data as RGBA float values.
+
+```csharp
+public static ReadOnlySpan<float> LoadEXR(
+    string filename,
+    out int width,
+    out int height,
+    out float* nativePtr)
+```
+
+The returned span has length `width * height * 4`. Free `nativePtr` with `FreeImageData` when done.
+
+### LoadEXRWithLayer
+
+Loads an EXR image with a specific layer from a file.
+
+```csharp
+public static ReadOnlySpan<float> LoadEXRWithLayer(
+    string filename,
+    string layerName,
+    out int width,
+    out int height,
+    out float* nativePtr)
+```
+
+Free `nativePtr` with `FreeImageData` when done.
+
+### LoadEXRFromMemory
+
+Loads an EXR image from a byte buffer in memory.
+
+```csharp
+public static ReadOnlySpan<float> LoadEXRFromMemory(
+    ReadOnlySpan<byte> memory,
+    out int width,
+    out int height,
+    out float* nativePtr)
+```
+
+Free `nativePtr` with `FreeImageData` when done.
+
+## Saving
+
+### SaveEXR
+
+Saves RGBA float data to an EXR file.
+
+```csharp
+public static void SaveEXR(
+    ReadOnlySpan<float> data,
+    int width,
+    int height,
+    int components,
+    bool saveAsFp16,
+    string filename)
+```
+
+- `components`: number of channels (typically 4 for RGBA).
+- `saveAsFp16`: `true` to save as half-precision floats, `false` for full 32-bit.
+
+### SaveEXRToMemory
+
+Saves RGBA float data to an EXR in memory.
+
+```csharp
+public static ReadOnlySpan<byte> SaveEXRToMemory(
+    ReadOnlySpan<float> data,
+    int width,
+    int height,
+    int components,
+    bool saveAsFp16,
+    out byte* nativePtr)
+```
+
+Returns the EXR file bytes as a span. Free `nativePtr` with `FreeMemoryBuffer` when done.
+
+## Validation
+
+### IsEXR
+
+Checks if a file is a valid EXR image.
+
+```csharp
+public static bool IsEXR(string filename)
+```
+
+### IsEXRFromMemory
+
+Checks if a byte buffer contains a valid EXR image.
+
+```csharp
+public static bool IsEXRFromMemory(ReadOnlySpan<byte> memory)
+```
+
+## Version parsing
+
+### ParseEXRVersionFromFile
+
+Parses the EXR version header from a file.
+
+```csharp
+public static EXRVersion ParseEXRVersionFromFile(string filename)
+```
+
+### ParseEXRVersionFromMemory
+
+Parses the EXR version header from a byte buffer.
+
+```csharp
+public static EXRVersion ParseEXRVersionFromMemory(ReadOnlySpan<byte> memory)
+```
+
+## Memory management
+
+### FreeImageData
+
+Frees image data returned by `LoadEXR`, `LoadEXRWithLayer`, or `LoadEXRFromMemory`.
+
+```csharp
+public static void FreeImageData(float* data)
+```
+
+### FreeMemoryBuffer
+
+Frees a buffer returned by `SaveEXRToMemory`.
+
+```csharp
+public static void FreeMemoryBuffer(byte* buffer)
+```

--- a/olve-packages/skills/olve-tinyexr/references/Types.md
+++ b/olve-packages/skills/olve-tinyexr/references/Types.md
@@ -1,0 +1,70 @@
+# Types
+
+API docs: [https://olivervea.github.io/Olve.Utilities/api/Olve.TinyEXR.html](https://olivervea.github.io/Olve.Utilities/api/Olve.TinyEXR.html)
+
+## TinyExrException
+
+Exception thrown when a tinyexr native call fails.
+
+**Namespace:** `Olve.TinyEXR`
+
+```csharp
+public sealed class TinyExrException : Exception
+```
+
+### Constructor
+
+```csharp
+public TinyExrException(int code, string? message)
+```
+
+- `code`: the native tinyexr error code.
+- `message`: the native error message, or a default message if null.
+
+### Properties
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `Code` | `int` | The native tinyexr error code. |
+| `Message` | `string` | Inherited from `Exception`. Contains the native error description or `"TinyEXR error {code}"`. |
+
+### Error codes
+
+| Code | Constant |
+| --- | --- |
+| 0 | `TINYEXR_SUCCESS` |
+| -1 | `TINYEXR_ERROR_INVALID_MAGIC_NUMBER` |
+| -2 | `TINYEXR_ERROR_INVALID_EXR_VERSION` |
+| -3 | `TINYEXR_ERROR_INVALID_ARGUMENT` |
+| -4 | `TINYEXR_ERROR_INVALID_DATA` |
+| -5 | `TINYEXR_ERROR_INVALID_FILE` |
+| -6 | `TINYEXR_ERROR_INVALID_PARAMETER` |
+| -7 | `TINYEXR_ERROR_CANT_OPEN_FILE` |
+| -8 | `TINYEXR_ERROR_UNSUPPORTED_FORMAT` |
+| -9 | `TINYEXR_ERROR_INVALID_HEADER` |
+| -10 | `TINYEXR_ERROR_UNSUPPORTED_FEATURE` |
+| -11 | `TINYEXR_ERROR_CANT_WRITE_FILE` |
+| -12 | `TINYEXR_ERROR_SERIALIZATION_FAILED` |
+| -13 | `TINYEXR_ERROR_LAYER_NOT_FOUND` |
+| -14 | `TINYEXR_ERROR_DATA_TOO_LARGE` |
+
+## EXRVersion
+
+Parsed EXR version header information.
+
+**Namespace:** `Olve.TinyEXR`
+
+```csharp
+[StructLayout(LayoutKind.Sequential)]
+public struct EXRVersion
+```
+
+### Fields
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `version` | `int` | EXR format version number (typically 2). |
+| `tiled` | `int` | Non-zero if the image uses tiled storage. |
+| `long_name` | `int` | Non-zero if the image uses long channel/attribute names. |
+| `non_image` | `int` | Non-zero if the file contains non-image data (deep data). |
+| `multipart` | `int` | Non-zero if the file is a multipart EXR. |

--- a/olve-packages/skills/olve-utilities/SKILL.md
+++ b/olve-packages/skills/olve-utilities/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: olve-utilities
+description: Reference for Olve.Utilities — meta-package with typed IDs, specialized collections, directed graphs, pagination, sentinel types, datetime formatting, and extension methods. Use when writing or reading code that uses Olve.Utilities types.
+user-invocable: false
+---
+
+# Olve.Utilities
+
+Meta-package bundling typed IDs, specialized collections, graphs, pagination, sentinel types, and extensions. Source: `Olve.Utilities/src/Olve.Utilities/`.
+
+Reference docs: [README](references/README.md) | [Ids](references/Ids.md) | [Collections](references/Collections.md) | [Graphs](references/Graphs.md) | [Pagination](references/Pagination.md) | [Types](references/Types.md) | [Extensions](references/Extensions.md) | [Other](references/Other.md)
+
+## Typed IDs
+
+```csharp
+var userId = Id.New<User>();
+var aliceId = Id.FromName<User>("alice");   // deterministic UUIDv5
+Id.TryParse<User>(userId.Value.ToString(), out var parsed);
+```
+
+## BidirectionalDictionary
+
+```csharp
+var dict = new BidirectionalDictionary<string, int>();
+dict.Set("alice", 1);
+dict.TryGet("alice", out var id);   // 1
+dict.TryGet(1, out var name);       // "alice"
+```
+
+## OneToManyLookup
+
+```csharp
+var lookup = new OneToManyLookup<string, int>();
+lookup.Set("alice", 1, true);
+lookup.Set("alice", 2, true);
+lookup.TryGet("alice", out var values); // { 1, 2 }
+lookup.TryGet(1, out var owner);        // "alice"
+```
+
+## ManyToManyLookup
+
+```csharp
+var enrollment = new ManyToManyLookup<string, int>();
+enrollment.Set("alice", 101, true);
+enrollment.Set("bob", 101, true);
+enrollment.TryGet("alice", out var courses); // { 101 }
+enrollment.TryGet(101, out var students);    // { "alice", "bob" }
+```
+
+## FixedSizeQueue
+
+```csharp
+var queue = new FixedSizeQueue<string>(maxSize: 3);
+queue.Enqueue("a");
+queue.Enqueue("b");
+queue.Enqueue("c");
+queue.Enqueue("d"); // "a" is dropped
+```
+
+## DirectedGraph
+
+```csharp
+var graph = new DirectedGraph();
+var a = graph.CreateNode();
+var b = graph.CreateNode();
+graph.CreateEdge(a, b);
+graph.TryGetOutgoingEdges(a, out var edges); // 1 edge
+```
+
+## Pagination
+
+```csharp
+var pagination = new Pagination(Page: 0, PageSize: 10);
+// pagination.Offset == 0
+
+var result = new PaginatedResult<string>(items, pagination, totalCount: 100);
+// result.TotalPages == 10, result.HasNextPage == true
+```
+
+## Sentinel Types
+
+Zero-size marker types for use with `OneOf<T>` discriminated unions:
+
+```csharp
+OneOf<User, NotFound> result = new NotFound();
+OneOf<Success, AlreadyExists> upsertResult = new Success();
+```
+
+## DictionaryExtensions
+
+```csharp
+var cache = new Dictionary<string, List<int>>();
+var list = cache.GetOrAdd("scores", () => []);
+cache.TryUpdate("scores", old => [..old, 200]);
+```

--- a/olve-packages/skills/olve-utilities/references/Collections.md
+++ b/olve-packages/skills/olve-utilities/references/Collections.md
@@ -1,0 +1,163 @@
+# Collections
+
+API docs: [https://olivervea.github.io/Olve.Utilities/api/Olve.Utilities.Collections.html](https://olivervea.github.io/Olve.Utilities/api/Olve.Utilities.Collections.html)
+
+Source: `src/Olve.Utilities/Collections/`
+
+## IReadOnlyBidirectionalDictionary\<T1, T2\>
+
+```csharp
+public interface IReadOnlyBidirectionalDictionary<T1, T2> : IEnumerable<KeyValuePair<T1, T2>>
+    where T1 : notnull where T2 : notnull
+{
+    bool IsSynced { get; }
+    int Count { get; }
+    IReadOnlyCollection<T1> FirstValues { get; }
+    IReadOnlyCollection<T2> SecondValues { get; }
+    bool Contains(T1 first);
+    bool Contains(T2 second);
+    bool TryGet(T1 first, out T2 second);
+    bool TryGet(T2 second, out T1 first);
+}
+```
+
+## IBidirectionalDictionary\<T1, T2\>
+
+Extends `IReadOnlyBidirectionalDictionary<T1, T2>`.
+
+```csharp
+public interface IBidirectionalDictionary<T1, T2> : IReadOnlyBidirectionalDictionary<T1, T2>
+    where T1 : notnull where T2 : notnull
+{
+    bool TryAdd(T1 first, T2 second);
+    void Set(T1 first, T2 second);
+    bool TryRemove(T1 first);
+    bool TryRemove(T2 second);
+    void Clear();
+}
+```
+
+## BidirectionalDictionary\<T1, T2\>
+
+Implements `IBidirectionalDictionary<T1, T2>`. Two-way lookup backed by two internal dictionaries.
+
+```csharp
+public class BidirectionalDictionary<T1, T2> : IBidirectionalDictionary<T1, T2>
+    where T1 : notnull where T2 : notnull
+{
+    public BidirectionalDictionary(
+        IEnumerable<KeyValuePair<T1, T2>>? collection = null,
+        IEqualityComparer<T1>? firstComparer = null,
+        IEqualityComparer<T2>? secondComparer = null);
+}
+```
+
+## ReadOnlyBidirectionalDictionary\<T1, T2\>
+
+Implements `IReadOnlyBidirectionalDictionary<T1, T2>`.
+
+```csharp
+public class ReadOnlyBidirectionalDictionary<T1, T2> : IReadOnlyBidirectionalDictionary<T1, T2>
+    where T1 : notnull where T2 : notnull
+{
+    public ReadOnlyBidirectionalDictionary(IEnumerable<KeyValuePair<T1, T2>> collection);
+}
+```
+
+## IOneToManyLookup\<TLeft, TRight\>
+
+One-to-many relationship. Forward lookup returns `IReadOnlySet<TRight>`, reverse lookup returns single `TLeft`.
+
+```csharp
+public interface IOneToManyLookup<TLeft, TRight> : IEnumerable<KeyValuePair<TLeft, IReadOnlySet<TRight>>>
+    where TLeft : notnull where TRight : notnull
+{
+    IEnumerable<TLeft> Lefts { get; }
+    IEnumerable<TRight> Rights { get; }
+    bool Contains(TLeft left, TRight right);
+    bool TryGet(TLeft left, out IReadOnlySet<TRight>? rights);
+    bool TryGet(TRight right, out TLeft left);
+    void Set(TLeft left, ISet<TRight> rights);
+    bool Set(TLeft left, TRight right, bool value);
+    void Clear();
+    bool Remove(TLeft left);
+    bool Remove(TRight right);
+    bool Remove(TLeft left, TRight right);
+}
+```
+
+## OneToManyLookup\<TLeft, TRight\>
+
+Implements `IOneToManyLookup<TLeft, TRight>`.
+
+```csharp
+public class OneToManyLookup<TLeft, TRight> : IOneToManyLookup<TLeft, TRight>
+    where TLeft : notnull where TRight : notnull
+{
+    public OneToManyLookup(
+        IEqualityComparer<TLeft>? leftComparer = null,
+        IEqualityComparer<TRight>? rightComparer = null);
+}
+```
+
+## IManyToManyLookup\<TLeft, TRight\>
+
+Many-to-many relationship. Both directions return `IReadOnlySet`.
+
+```csharp
+public interface IManyToManyLookup<TLeft, TRight> : IEnumerable<KeyValuePair<TLeft, TRight>>
+    where TLeft : notnull where TRight : notnull
+{
+    IEnumerable<TLeft> Lefts { get; }
+    IEnumerable<TRight> Rights { get; }
+    bool Contains(TLeft left, TRight right);
+    bool TryGet(TLeft left, out IReadOnlySet<TRight>? rights);
+    bool TryGet(TRight right, out IReadOnlySet<TLeft>? lefts);
+    void Set(TLeft left, ISet<TRight> rights);
+    void Set(TRight right, ISet<TLeft> lefts);
+    bool Set(TLeft left, TRight right, bool value);
+    bool Set(TRight right, TLeft left, bool value);
+    void Clear();
+    bool Remove(TLeft left);
+    bool Remove(TRight right);
+}
+```
+
+## ManyToManyLookup\<TLeft, TRight\>
+
+Implements `IManyToManyLookup<TLeft, TRight>`.
+
+```csharp
+public class ManyToManyLookup<TLeft, TRight> : IManyToManyLookup<TLeft, TRight>
+    where TLeft : notnull where TRight : notnull
+{
+    public ManyToManyLookup(
+        IEnumerable<KeyValuePair<TLeft, TRight>>? initialItems = null,
+        IEqualityComparer<TLeft>? leftComparer = null,
+        IEqualityComparer<TRight>? rightComparer = null);
+}
+```
+
+## IQueue\<T\>
+
+```csharp
+public interface IQueue<T> : IEnumerable<T>
+{
+    void Enqueue(T item);
+    bool TryDequeue(out T item);
+    bool TryPeek(out T item);
+    int Count { get; }
+    void Clear();
+}
+```
+
+## FixedSizeQueue\<T\>
+
+Implements `IQueue<T>`. Automatically drops oldest items when `maxSize` is exceeded.
+
+```csharp
+public class FixedSizeQueue<T> : IQueue<T>
+{
+    public FixedSizeQueue(int maxSize);
+}
+```

--- a/olve-packages/skills/olve-utilities/references/Extensions.md
+++ b/olve-packages/skills/olve-utilities/references/Extensions.md
@@ -1,0 +1,112 @@
+# Extensions
+
+API docs: [https://olivervea.github.io/Olve.Utilities/api/Olve.Utilities.CollectionExtensions.html](https://olivervea.github.io/Olve.Utilities/api/Olve.Utilities.CollectionExtensions.html)
+
+Source: `src/Olve.Utilities/CollectionExtensions/` and `src/Olve.Utilities/Extensions/`
+
+## DictionaryExtensions
+
+High-performance extensions using `CollectionsMarshal` for zero-overhead dictionary operations. Single-threaded only.
+
+```csharp
+public static class DictionaryExtensions
+{
+    // Get existing value or create and add via factory
+    public static TValue GetOrAdd<TKey, TValue>(
+        this Dictionary<TKey, TValue> dictionary, TKey key, Func<TValue> valueFactory)
+        where TKey : notnull;
+
+    // Get existing value or add the provided value
+    public static TValue GetOrAdd<TKey, TValue>(
+        this Dictionary<TKey, TValue> dictionary, TKey key, TValue value)
+        where TKey : notnull;
+
+    // Update value if key exists (direct value)
+    public static bool TryUpdate<TKey, TValue>(
+        this Dictionary<TKey, TValue> dictionary, TKey key, TValue value)
+        where TKey : notnull;
+
+    // Update value if key exists (transform function)
+    public static bool TryUpdate<TKey, TValue>(
+        this Dictionary<TKey, TValue> dictionary, TKey key, Func<TValue, TValue> update)
+        where TKey : notnull;
+}
+```
+
+## EnumerableExtensions
+
+```csharp
+public static class EnumerableExtensions
+{
+    // Lazy projection (alias for Select)
+    public static IEnumerable<TOut> ForEach<TIn, TOut>(
+        this IEnumerable<TIn> enumerable, Func<TIn, TOut> action);
+
+    // Eager side-effect iteration
+    public static void ForEach<T>(this IEnumerable<T> enumerable, Action<T> action);
+
+    // Product of float sequence
+    public static float Product(this IEnumerable<float> enumerable);
+
+    // Try cast to IReadOnlySet<T>
+    public static bool TryAsReadOnlySet<T>(
+        this IEnumerable<T> enumerable, out IReadOnlySet<T>? readOnlySet);
+
+    // Try cast to ISet<T>
+    public static bool TryAsSet<T>(this IEnumerable<T> enumerable, out ISet<T>? set);
+}
+```
+
+## ISetExtensions
+
+```csharp
+public static class ISetExtensions
+{
+    // Toggle: add if missing, remove if present. Returns true if added.
+    public static bool Toggle<T>(this ISet<T> set, T item);
+
+    // Set: add if value=true, remove if value=false. Returns true if changed.
+    public static bool Set<T>(this ISet<T> set, T item, bool value);
+}
+```
+
+## RandomExtensions
+
+```csharp
+public static class RandomExtensions
+{
+    // Pick a single random element (throws if empty)
+    public static T PickRandom<T>(this IEnumerable<T> source);
+
+    // Pick a single random element or default
+    public static T? PickRandomOrDefault<T>(this IEnumerable<T> source);
+
+    // Pick N random elements
+    public static IEnumerable<T> PickRandom<T>(this IEnumerable<T> source, int count);
+}
+```
+
+## OneOfTryGetExtensions
+
+```csharp
+public static class OneOfTryGetExtensions
+{
+    public static T0 GetT0OrDefault<T0, T1>(this OneOf<T0, T1> oneOf, T0 defaultValue);
+    public static T1 GetT1OrDefault<T0, T1>(this OneOf<T0, T1> oneOf, T1 defaultValue);
+    public static T0 GetT0OrDefault<T0, T1, T2>(this OneOf<T0, T1, T2> oneOf, T0 defaultValue);
+}
+```
+
+## EnumerableOneOfExtensions
+
+Generated overloads for checking if any element in a sequence of `OneOf` values matches a specific variant. Methods follow the pattern `AnyT0`, `AnyT1`, etc. for `OneOf` types with up to 8 type parameters.
+
+```csharp
+public static class EnumerableOneOfExtensions
+{
+    public static bool AnyT0<T0>(this IEnumerable<OneOf<T0>> source);
+    public static bool AnyT0<T0, T1>(this IEnumerable<OneOf<T0, T1>> source);
+    public static bool AnyT1<T0, T1>(this IEnumerable<OneOf<T0, T1>> source);
+    // ... overloads up to AnyT7 for OneOf with up to 8 type params
+}
+```

--- a/olve-packages/skills/olve-utilities/references/Graphs.md
+++ b/olve-packages/skills/olve-utilities/references/Graphs.md
@@ -1,0 +1,52 @@
+# Graphs
+
+API docs: [https://olivervea.github.io/Olve.Utilities/api/Olve.Utilities.Graphs.html](https://olivervea.github.io/Olve.Utilities/api/Olve.Utilities.Graphs.html)
+
+Source: `src/Olve.Utilities/Graphs/`
+
+## Node
+
+```csharp
+public readonly record struct Node(Id<Node> Id);
+```
+
+## DirectedEdge
+
+```csharp
+public readonly record struct DirectedEdge(Id<DirectedEdge> Id, Id<Node> From, Id<Node> To);
+```
+
+## DirectedGraph
+
+ID-based directed graph with node and edge management.
+
+```csharp
+public class DirectedGraph
+{
+    // Properties
+    public IReadOnlyCollection<Id<Node>> NodeIds { get; }
+    public IReadOnlyCollection<Node> Nodes { get; }
+    public IReadOnlyCollection<Id<DirectedEdge>> EdgeIds { get; }
+    public IReadOnlyCollection<DirectedEdge> Edges { get; }
+
+    // Node operations
+    public Id<Node> CreateNode();
+    public bool TryGetNode(Id<Node> nodeId, out Node node);
+    public bool DeleteNode(Id<Node> nodeId);
+
+    // Edge operations
+    public Id<DirectedEdge> CreateEdge(Id<Node> from, Id<Node> to);
+    public bool TryGetEdge(Id<DirectedEdge> edgeId, out DirectedEdge edge);
+    public bool DeleteEdge(Id<DirectedEdge> edgeId);
+
+    // Traversal
+    public bool TryFollowEdge(Id<Node> from, Id<DirectedEdge> edgeId, out Id<Node> to);
+    public bool TryGetIncomingEdges(Id<Node> nodeId, out IReadOnlySet<Id<DirectedEdge>>? edges);
+    public bool TryGetOutgoingEdges(Id<Node> nodeId, out IReadOnlySet<Id<DirectedEdge>>? edges);
+}
+```
+
+- `CreateNode` returns a new randomly-generated `Id<Node>`.
+- `CreateEdge` returns a new `Id<DirectedEdge>` connecting two nodes.
+- `DeleteNode` also removes all connected edges.
+- `TryFollowEdge` verifies the edge starts at the given `from` node.

--- a/olve-packages/skills/olve-utilities/references/Ids.md
+++ b/olve-packages/skills/olve-utilities/references/Ids.md
@@ -1,0 +1,87 @@
+# Ids
+
+API docs: [https://olivervea.github.io/Olve.Utilities/api/Olve.Utilities.Ids.html](https://olivervea.github.io/Olve.Utilities/api/Olve.Utilities.Ids.html)
+
+Source: `src/Olve.Utilities/Ids/`
+
+## Id
+
+Opaque, type-agnostic identifier backed by a `Guid`. Implements `IComparable<Id>`.
+
+```csharp
+public readonly record struct Id(Guid Value) : IComparable<Id>
+{
+    public Guid Value { get; }
+    public static Id New();
+    public static Id<T> New<T>();
+    public static Id FromName(string name, Id? namespaceId = null);
+    public static Id<T> FromName<T>(string name, Id? namespaceId = null);
+    public static bool TryParse(string text, out Id id);
+    public static bool TryParse<T>(string text, out Id<T> id);
+    public int CompareTo(Id other);
+    public override string ToString();
+    public string ToDisplayString();
+
+    public static bool operator <(Id left, Id right);
+    public static bool operator >(Id left, Id right);
+    public static bool operator <=(Id left, Id right);
+    public static bool operator >=(Id left, Id right);
+}
+```
+
+- `New()` / `New<T>()` -- random GUID-based ID.
+- `FromName` / `FromName<T>` -- deterministic UUIDv5 from a string name and optional namespace.
+- `TryParse` / `TryParse<T>` -- parse a GUID string into an Id.
+
+## Id\<T\>
+
+Lightweight, type-safe wrapper around `Id`. The type parameter `T` is used only for compile-time safety.
+
+```csharp
+public readonly record struct Id<T> : IComparable<Id<T>>
+{
+    public Id Value { get; }
+    public Id(Id value);
+    public int CompareTo(Id<T> other);
+    public override string ToString();
+    public string ToDisplayString();
+
+    public static bool operator <(Id<T> left, Id<T> right);
+    public static bool operator >(Id<T> left, Id<T> right);
+    public static bool operator <=(Id<T> left, Id<T> right);
+    public static bool operator >=(Id<T> left, Id<T> right);
+}
+```
+
+## UnionId\<T1, T2\>
+
+Tagged union of `Id<T1>` and `Id<T2>`. Requires `T1 != T2` (enforced at static constructor time).
+
+```csharp
+public readonly record struct UnionId<T1, T2> : IComparable<UnionId<T1, T2>>
+{
+    public bool IsT1 { get; }
+    public bool IsT2 { get; }
+
+    public static UnionId<T1, T2> FromT1(Id<T1> id);
+    public static UnionId<T1, T2> FromT2(Id<T2> id);
+
+    public static implicit operator UnionId<T1, T2>(Id<T1> id);
+    public static implicit operator UnionId<T1, T2>(Id<T2> id);
+
+    public Id<T1> AsT1();
+    public Id<T2> AsT2();
+
+    public bool TryGetT1(out Id<T1> value, out Id<T2> remainder);
+    public bool TryGetT2(out Id<T2> value, out Id<T1> remainder);
+
+    public TResult Match<TResult>(Func<Id<T1>, TResult> whenT1, Func<Id<T2>, TResult> whenT2);
+    public void Switch(Action<Id<T1>> whenT1, Action<Id<T2>> whenT2);
+
+    public int CompareTo(UnionId<T1, T2> other);
+}
+```
+
+- Implicit conversions from `Id<T1>` and `Id<T2>`.
+- `TryGetT1` / `TryGetT2` return the held variant and provide the other as `remainder`.
+- `Match` / `Switch` for exhaustive pattern matching.

--- a/olve-packages/skills/olve-utilities/references/Other.md
+++ b/olve-packages/skills/olve-utilities/references/Other.md
@@ -1,0 +1,197 @@
+# Other Utilities
+
+Source: various subdirectories under `src/Olve.Utilities/`
+
+## IAsyncOnStartup
+
+API docs: [https://olivervea.github.io/Olve.Utilities/api/Olve.Utilities.AsyncOnStartup.html](https://olivervea.github.io/Olve.Utilities/api/Olve.Utilities.AsyncOnStartup.html)
+
+Priority-based async startup task interface. Register implementations as `IAsyncOnStartup` in DI. Tasks with the same priority run concurrently; groups execute in ascending priority order.
+
+```csharp
+public interface IAsyncOnStartup
+{
+    int Priority => 0;
+    Task OnStartupAsync(CancellationToken cancellationToken = default);
+}
+```
+
+### ServiceProviderExtensions
+
+```csharp
+public static class ServiceProviderExtensions
+{
+    // Runs all IAsyncOnStartup services in priority order
+    public static ValueTask RunAsyncOnStartup(
+        this IServiceProvider serviceProvider,
+        CancellationToken cancellationToken = default);
+}
+```
+
+## IBuilder\<T\>
+
+API docs: [https://olivervea.github.io/Olve.Utilities/api/Olve.Utilities.Builders.html](https://olivervea.github.io/Olve.Utilities/api/Olve.Utilities.Builders.html)
+
+Builder pattern interface with optional validation integration.
+
+```csharp
+public interface IBuilder<out T>
+{
+    T Build();
+}
+
+public static class BuilderExtensions
+{
+    // Build and validate in one step
+    public static Result<T> ValidateAndBuild<T, TValidator>(
+        this IBuilder<T> builder, TValidator validator)
+        where TValidator : IValidator<T>;
+}
+```
+
+## ProjectFileNameHelper
+
+API docs: [https://olivervea.github.io/Olve.Utilities/api/Olve.Utilities.Projects.html](https://olivervea.github.io/Olve.Utilities/api/Olve.Utilities.Projects.html)
+
+Generates structured file names from elements with a delimiter and extension.
+
+```csharp
+public class ProjectFileNameHelper(string? delimiter = null, string? extension = null)
+{
+    public string FileNameDelimiter { get; }
+    public string FileExtension { get; }
+    public string GetFileName(IEnumerable<string> elements);
+    public IEnumerable<string> GetElements(string fileName,
+        StringComparison comparisonType = StringComparison.Ordinal);
+}
+```
+
+## ProjectFolderHelper
+
+API docs: [https://olivervea.github.io/Olve.Utilities/api/Olve.Utilities.Projects.html](https://olivervea.github.io/Olve.Utilities/api/Olve.Utilities.Projects.html)
+
+Manages project folder paths with OS-aware defaults (XDG_DATA_HOME on Linux, CommonApplicationData on Windows).
+
+```csharp
+public class ProjectFolderHelper(
+    string projectName,
+    string organization = "Olve",
+    Environment.SpecialFolder? specialFolder = null)
+{
+    public string ProjectName { get; }
+    public string Organization { get; }
+    public Environment.SpecialFolder? SpecialFolder { get; }
+    public IPath RootDirectory { get; set; }
+    public IPath ProjectRootFolder { get; }  // RootDirectory / Organization / ProjectName
+}
+```
+
+## DateTimeFormatter
+
+API docs: [https://olivervea.github.io/Olve.Utilities/api/Olve.Utilities.StringFormatting.html](https://olivervea.github.io/Olve.Utilities/api/Olve.Utilities.StringFormatting.html)
+
+Human-readable relative time formatting.
+
+```csharp
+public static class DateTimeFormatter
+{
+    // Returns e.g. "2 days ago", "1 hour ago", "just now"
+    public static string FormatTimeAgo(DateTimeOffset now, DateTimeOffset then);
+}
+```
+
+## IntegerMath2D
+
+API docs: [https://olivervea.github.io/Olve.Utilities/api/Olve.Utilities.IntegerMath2D.html](https://olivervea.github.io/Olve.Utilities/api/Olve.Utilities.IntegerMath2D.html)
+
+Integer-based 2D math types.
+
+### Position
+
+```csharp
+public readonly record struct Position(int X, int Y)
+{
+    public static DeltaPosition operator -(Position a, Position b);
+    public static Position operator +(Position a, DeltaPosition b);
+    public static implicit operator Position((int X, int Y) tuple);
+}
+```
+
+### Size
+
+```csharp
+public readonly record struct Size(int Width, int Height)
+{
+    public static implicit operator Size((int Width, int Height) tuple);
+}
+```
+
+### DeltaPosition
+
+```csharp
+public readonly record struct DeltaPosition(int X, int Y)
+{
+    public static DeltaPosition operator +(DeltaPosition a, DeltaPosition b);
+    public static DeltaPosition operator -(DeltaPosition a, DeltaPosition b);
+    public static DeltaPosition operator *(DeltaPosition a, int scalar);
+}
+```
+
+## Assert
+
+API docs: [https://olivervea.github.io/Olve.Utilities/api/Olve.Utilities.Assertions.html](https://olivervea.github.io/Olve.Utilities/api/Olve.Utilities.Assertions.html)
+
+Debug-only assertion methods. All methods are annotated with `[Conditional("DEBUG")]`.
+
+```csharp
+public static class Assert
+{
+    public static void That(Func<bool> assertion, string message);
+    public static void NotNull<T>(T? value, string message = "Value cannot be null.") where T : class;
+    public static void IsEmpty<T>(IEnumerable<T> collection, string message = "Collection should be empty.");
+    public static void IsNotEmpty<T>(IEnumerable<T> collection, string message = "Collection should not be empty.");
+}
+
+public class AssertionError(string message) : Exception(message);
+```
+
+## FrozenLookupBase\<TKey, TValue\>
+
+API docs: [https://olivervea.github.io/Olve.Utilities/api/Olve.Utilities.Lookup.html](https://olivervea.github.io/Olve.Utilities/api/Olve.Utilities.Lookup.html)
+
+Immutable lookup backed by `FrozenDictionary`.
+
+```csharp
+public class FrozenLookupBase<TKey, TValue>(IEnumerable<KeyValuePair<TKey, TValue>> items)
+    : IReadOnlyCollection<KeyValuePair<TKey, TValue>>
+    where TKey : notnull
+{
+    public IReadOnlyCollection<TKey> Keys { get; }
+    public IReadOnlyCollection<TValue> Values { get; }
+    public IReadOnlyCollection<KeyValuePair<TKey, TValue>> Items { get; }
+    public int Count { get; }
+    public bool ContainsKey(TKey key);
+    public bool ContainsValue(TValue value);  // O(n)
+    public bool TryGetValue(TKey key, out TValue value);
+}
+```
+
+## IdFrozenLookup\<T, TId\>
+
+Extends `FrozenLookupBase` to map items by their `Id` property.
+
+```csharp
+public class IdFrozenLookup<T, TId>(IEnumerable<T> items)
+    : FrozenLookupBase<TId, T>
+    where T : IHasId<TId>
+    where TId : notnull;
+```
+
+### IHasId\<TId\>
+
+```csharp
+public interface IHasId<out TId> where TId : notnull
+{
+    TId Id { get; }
+}
+```

--- a/olve-packages/skills/olve-utilities/references/Pagination.md
+++ b/olve-packages/skills/olve-utilities/references/Pagination.md
@@ -1,0 +1,38 @@
+# Pagination
+
+API docs: [https://olivervea.github.io/Olve.Utilities/api/Olve.Utilities.Paginations.html](https://olivervea.github.io/Olve.Utilities/api/Olve.Utilities.Paginations.html)
+
+Source: `src/Olve.Utilities/Paginations/`
+
+## Pagination
+
+Computes offset from zero-based page number and page size.
+
+```csharp
+public readonly record struct Pagination(int Page, int PageSize)
+{
+    public int Offset { get; } // == Page * PageSize
+}
+```
+
+## PaginatedResult\<T\>
+
+Wraps a page of items with total count and navigation metadata. Implements `IReadOnlyList<T>`.
+
+```csharp
+public sealed class PaginatedResult<T>(IList<T> items, Pagination pagination, int totalCount)
+    : IReadOnlyList<T>
+{
+    public required int TotalCount { get; init; }
+    public int TotalPages { get; }       // ceil(TotalCount / PageSize), 0 if PageSize == 0
+    public required int Page { get; init; }
+    public required int PageSize { get; init; }
+    public bool HasNextPage { get; }     // (Page + 1) * PageSize < TotalCount
+    public Pagination? Next { get; }     // next page Pagination, or null if last page
+
+    // IReadOnlyList<T>
+    public int Count { get; }
+    public T this[int index] { get; }
+    public IEnumerator<T> GetEnumerator();
+}
+```

--- a/olve-packages/skills/olve-utilities/references/README.md
+++ b/olve-packages/skills/olve-utilities/references/README.md
@@ -1,0 +1,27 @@
+# Olve.Utilities Reference
+
+API docs: [https://olivervea.github.io/Olve.Utilities/api/Olve.Utilities.html](https://olivervea.github.io/Olve.Utilities/api/Olve.Utilities.html)
+
+`Olve.Utilities` is a meta-package that also brings in `Olve.Results`, `Olve.Paths`, and `Olve.Validation`.
+
+## Reference Files
+
+| File | Contents |
+| --- | --- |
+| [Ids](Ids.md) | `Id`, `Id<T>`, `UnionId<T1,T2>` -- GUID-backed typed identifiers |
+| [Collections](Collections.md) | `BidirectionalDictionary`, `OneToManyLookup`, `ManyToManyLookup`, `FixedSizeQueue` |
+| [Graphs](Graphs.md) | `Node`, `DirectedEdge`, `DirectedGraph` |
+| [Pagination](Pagination.md) | `Pagination`, `PaginatedResult<T>` |
+| [Types](Types.md) | Sentinel types: `NotFound`, `Success`, `AlreadyExists`, `Skipped`, `Waiting`, `Any`, `Yes` |
+| [Extensions](Extensions.md) | `DictionaryExtensions`, `EnumerableExtensions`, `ISetExtensions`, `RandomExtensions`, `OneOfTryGetExtensions`, `EnumerableOneOfExtensions` |
+| [Other](Other.md) | `IAsyncOnStartup`, `IBuilder<T>`, `ProjectFileNameHelper`, `ProjectFolderHelper`, `DateTimeFormatter`, `Position`, `Size`, `DeltaPosition`, `Assert`, `FrozenLookupBase`, `IdFrozenLookup` |
+
+## Installation
+
+```bash
+dotnet add package Olve.Utilities
+```
+
+## Source Location
+
+`src/Olve.Utilities/`

--- a/olve-packages/skills/olve-utilities/references/Types.md
+++ b/olve-packages/skills/olve-utilities/references/Types.md
@@ -1,0 +1,129 @@
+# Sentinel Types
+
+API docs: [https://olivervea.github.io/Olve.Utilities/api/Olve.Utilities.Types.html](https://olivervea.github.io/Olve.Utilities/api/Olve.Utilities.Types.html)
+
+Source: `src/Olve.Utilities/Types/`
+
+Zero-size marker types (`Size = 1` byte) for use with `OneOf<T>` discriminated unions. Each type has a non-generic and a generic variant.
+
+## NotFound / NotFound\<T\>
+
+Indicates a value was not found.
+
+```csharp
+public readonly struct NotFound
+{
+    public override string ToString(); // "NotFound"
+}
+
+public readonly struct NotFound<T>
+{
+    public override string ToString(); // "NotFound<TypeName>"
+}
+```
+
+## Success / Success\<T\>
+
+Indicates a successful operation.
+
+```csharp
+public readonly struct Success
+{
+    public override string ToString(); // "Success"
+}
+
+public readonly struct Success<T>
+{
+    public override string ToString(); // "Success<TypeName>"
+}
+```
+
+## AlreadyExists / AlreadyExists\<T\>
+
+Indicates something already exists.
+
+```csharp
+public readonly struct AlreadyExists
+{
+    public override string ToString(); // "AlreadyExists"
+}
+
+public readonly struct AlreadyExists<T>
+{
+    public override string ToString(); // "AlreadyExists<TypeName>"
+}
+```
+
+## Skipped / Skipped\<T\>
+
+Represents a skipped operation.
+
+```csharp
+public readonly struct Skipped
+{
+    public override string ToString(); // "Skipped"
+}
+
+public readonly struct Skipped<T>
+{
+    public override string ToString(); // "Skipped<TypeName>"
+}
+```
+
+## Waiting / Waiting\<T\>
+
+Represents a waiting state.
+
+```csharp
+public readonly struct Waiting
+{
+    public override string ToString(); // "Waiting"
+}
+
+public readonly struct Waiting<T>
+{
+    public override string ToString(); // "Waiting<TypeName>"
+}
+```
+
+## Any / Any\<T\>
+
+Represents anything / a wildcard.
+
+```csharp
+public readonly struct Any
+{
+    public override string ToString(); // "Any"
+}
+
+public readonly struct Any<T>
+{
+    public override string ToString(); // "Any<TypeName>"
+}
+```
+
+## Yes / Yes\<T\>
+
+Represents a type that is always true. The generic variant holds a value.
+
+```csharp
+public readonly struct Yes
+{
+    public override string ToString(); // "Yes"
+}
+
+public readonly record struct Yes<T>(T Value)
+{
+    public override string ToString(); // "Yes<TypeName>(Value)"
+}
+```
+
+## Usage with OneOf
+
+```csharp
+// Return type expressing "found or not found"
+OneOf<User, NotFound> GetUser(Id<User> id);
+
+// Return type expressing "created, already existed, or error"
+OneOf<Success, AlreadyExists, ResultProblem> CreateUser(User user);
+```

--- a/olve-packages/skills/olve-validation/SKILL.md
+++ b/olve-packages/skills/olve-validation/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: olve-validation
+description: Reference for Olve.Validation — fluent validators that accumulate rules and return Result with all problems found. Covers StringValidator, IntValidator, DecimalValidator, EnumerableValidator, ListValidator, IValidator<T>, IValidatable, and base validator classes. Use when writing or reading code that uses Olve.Validation.
+user-invocable: false
+---
+
+# Olve.Validation
+
+Fluent validation helpers built on top of Olve.Results. Validators accumulate rules and return a `Result` containing all problems found. Source: `Olve.Utilities/src/Olve.Validation/`.
+
+Reference docs: [README](references/README.md) | [Interfaces](references/Interfaces.md) | [BaseValidators](references/BaseValidators.md) | [ConcreteValidators](references/ConcreteValidators.md)
+
+## Quick Examples
+
+### String validation
+
+```csharp
+var result = new StringValidator()
+    .CannotBeNullOrWhiteSpace()
+    .MustHaveMinLength(3)
+    .MustHaveMaxLength(50)
+    .Validate("Alice");
+```
+
+### Numeric validation
+
+```csharp
+var result = new IntValidator()
+    .MustBePositive()
+    .MustBeLessThan(100)
+    .Validate(42);
+
+var decResult = new DecimalValidator<double>()
+    .MustBeBetween(0.0, 1.0)
+    .Validate(0.5);
+```
+
+### Collection validation
+
+```csharp
+var result = new EnumerableValidator<string>()
+    .CannotBeNull()
+    .CannotBeEmpty()
+    .CannotContainDuplicates()
+    .Validate(new[] { "a", "b", "c" });
+```
+
+### Custom error messages
+
+Use `WithMessage()` or `WithProblem()` after a rule to override its default error:
+
+```csharp
+var result = new StringValidator()
+    .CannotBeNullOrWhiteSpace()
+    .WithMessage("Username is required")
+    .MustHaveMinLength(3)
+    .WithMessage("Username must be at least 3 characters")
+    .Validate(null);
+```
+
+### Integration with Olve.Results
+
+Validators return `Result`, so they compose naturally with the rest of the Olve.Results API:
+
+```csharp
+Result ValidateEmail(string? email)
+{
+    return new StringValidator()
+        .CannotBeNullOrWhiteSpace()
+        .WithMessage("Email is required")
+        .Validate(email);
+}
+```
+
+## Key Patterns
+
+- Chain rules fluently, then call `Validate()` to get a `Result`.
+- When multiple rules fail, all problems are collected into the result.
+- Use `WithMessage()` / `WithProblem()` immediately after a rule to customize its error.
+- Validators implement `IValidator<T>`, so they can be passed around as interfaces.
+- Objects implementing `IValidatable` can validate their own state via a parameterless `Validate()`.

--- a/olve-packages/skills/olve-validation/references/BaseValidators.md
+++ b/olve-packages/skills/olve-validation/references/BaseValidators.md
@@ -1,0 +1,138 @@
+# Base Validators
+
+## BaseValidator\<TValue, TValidator\>
+
+https://olivervea.github.io/Olve.Utilities/api/Olve.Validation.Validators.Base.BaseValidator-2.html
+
+Abstract base class for all validators. Provides rule accumulation, validation execution, and error message overrides. Implements `IValidator<TValue>`. Namespace: `Olve.Validation.Validators.Base`.
+
+Constraints: `TValidator : BaseValidator<TValue, TValidator>` (CRTP for fluent chaining).
+
+Public members:
+
+```csharp
+public Result Validate(TValue value);
+public TValidator WithProblem(Func<TValue, ResultProblem> problemFactory);
+public TValidator WithProblem(ResultProblem problem);
+public TValidator WithMessage(string message);
+```
+
+Protected members:
+
+```csharp
+protected abstract TValidator Validator { get; }
+protected TValidator FailIf(Func<TValue, bool> condition, Func<TValue, ResultProblem> problemFactory);
+```
+
+- `Validate` runs all rules and aggregates problems. Returns `Result.Success()` if no rules fail.
+- `WithProblem` / `WithMessage` override the error of the most recently added rule. Throws `InvalidOperationException` if no rules exist or if the last rule's problem was already overwritten.
+- `FailIf` adds a rule that produces a problem when the condition returns true.
+
+---
+
+## BaseStructValidator\<TValue, TValidator\>
+
+https://olivervea.github.io/Olve.Utilities/api/Olve.Validation.Validators.Base.BaseStructValidator-2.html
+
+Inherits: `BaseValidator<TValue, TValidator>`. Namespace: `Olve.Validation.Validators.Base`.
+
+Constraints: `TValue : struct`, `TValidator : BaseStructValidator<TValue, TValidator>`.
+
+Protected members:
+
+```csharp
+protected TValidator CannotBeDefault();
+protected TValidator MustBeDefault();
+```
+
+- `CannotBeDefault` -- fails if value equals `default(TValue)`.
+- `MustBeDefault` -- fails if value does not equal `default(TValue)`.
+
+---
+
+## BaseObjectValidator\<TValue, TValidator\>
+
+https://olivervea.github.io/Olve.Utilities/api/Olve.Validation.Validators.Base.BaseObjectValidator-2.html
+
+Inherits: `BaseValidator<TValue?, TValidator>`. Namespace: `Olve.Validation.Validators.Base`.
+
+Constraints: `TValue : class`, `TValidator : BaseObjectValidator<TValue, TValidator>`.
+
+Note: validates `TValue?` (nullable reference type).
+
+Public members:
+
+```csharp
+public TValidator CannotBeNull();
+public TValidator MustBeOneOf(params ICollection<TValue?> values);
+public TValidator CannotBeOneOf(params ICollection<TValue?> values);
+```
+
+- `CannotBeNull` -- fails if value is null.
+- `MustBeOneOf` -- fails if value is not in the allowed collection.
+- `CannotBeOneOf` -- fails if value is in the disallowed collection.
+
+---
+
+## BaseNumericStructValidator\<TValue, TValidator\>
+
+https://olivervea.github.io/Olve.Utilities/api/Olve.Validation.Validators.Base.BaseNumericStructValidator-2.html
+
+Inherits: `BaseStructValidator<TValue, TValidator>`. Namespace: `Olve.Validation.Validators.Base`.
+
+Constraints: `TValue : struct, INumber<TValue>`, `TValidator : BaseNumericStructValidator<TValue, TValidator>`.
+
+Public members:
+
+```csharp
+public TValidator MustBeGreaterThan(TValue limit);
+public TValidator MustBeLessThan(TValue limit);
+public TValidator MustBeGreaterThanOrEqualTo(TValue limit);
+public TValidator MustBeLessThanOrEqualTo(TValue limit);
+public TValidator MustBeBetween(TValue min, TValue max);
+public TValidator MustBePositive();
+public TValidator MustBeNegative();
+public TValidator MustBeZero();
+```
+
+- `MustBeGreaterThan` -- fails when value <= limit.
+- `MustBeLessThan` -- fails when value >= limit.
+- `MustBeGreaterThanOrEqualTo` -- fails when value < limit.
+- `MustBeLessThanOrEqualTo` -- fails when value > limit.
+- `MustBeBetween` -- fails when value < min or value > max (inclusive range).
+- `MustBePositive` -- fails when value <= 0.
+- `MustBeNegative` -- fails when value >= 0.
+- `MustBeZero` -- fails when value != 0.
+
+---
+
+## BaseEnumerableValidator\<TValue, TEnumerable, TValidator\>
+
+https://olivervea.github.io/Olve.Utilities/api/Olve.Validation.Validators.Base.BaseEnumerableValidator-3.html
+
+Inherits: `BaseObjectValidator<TEnumerable, TValidator>`. Namespace: `Olve.Validation.Validators.Base`.
+
+Constraints: `TEnumerable : class, IEnumerable<TValue>`, `TValidator : BaseEnumerableValidator<TValue, TEnumerable, TValidator>`.
+
+Inherits from BaseObjectValidator, so `CannotBeNull()`, `MustBeOneOf()`, `CannotBeOneOf()` are available.
+
+Public members:
+
+```csharp
+public TValidator CannotBeEmpty();
+public TValidator CannotContainDuplicates();
+public TValidator MustHaveCountGreaterThan(int threshold);
+```
+
+Protected virtual members:
+
+```csharp
+protected virtual bool HasDuplicates(TEnumerable enumerable);
+protected virtual int GetCount(TEnumerable enumerable);
+```
+
+- `CannotBeEmpty` -- fails if enumerable is non-null but has no elements.
+- `CannotContainDuplicates` -- fails if enumerable contains duplicate elements.
+- `MustHaveCountGreaterThan` -- fails if element count is <= threshold.
+- `HasDuplicates` -- overridable duplicate detection (default uses `Distinct().Count()`).
+- `GetCount` -- overridable count (default uses LINQ `Count()`). `ListValidator<T>` overrides this with `IList<T>.Count`.

--- a/olve-packages/skills/olve-validation/references/ConcreteValidators.md
+++ b/olve-packages/skills/olve-validation/references/ConcreteValidators.md
@@ -1,0 +1,95 @@
+# Concrete Validators
+
+## StringValidator
+
+https://olivervea.github.io/Olve.Utilities/api/Olve.Validation.Validators.StringValidator.html
+
+Inherits: `BaseObjectValidator<string, StringValidator>`. Namespace: `Olve.Validation.Validators`.
+
+Validates `string?` values. Inherits `CannotBeNull()`, `MustBeOneOf()`, `CannotBeOneOf()` from BaseObjectValidator.
+
+Public members:
+
+```csharp
+public StringValidator CannotBeNullOrEmpty();
+public StringValidator CannotBeNullOrWhiteSpace();
+public StringValidator MustHaveMinLength(int minLength);
+public StringValidator MustHaveMaxLength(int maxLength);
+```
+
+- `CannotBeNullOrEmpty` -- fails when string is null or empty.
+- `CannotBeNullOrWhiteSpace` -- fails when string is null or whitespace.
+- `MustHaveMinLength` -- fails when string length < minLength. Throws `ArgumentException` if minLength < 0.
+- `MustHaveMaxLength` -- fails when string length > maxLength. Throws `ArgumentException` if maxLength < 0.
+
+Also inherits from BaseValidator: `Validate()`, `WithProblem()`, `WithMessage()`.
+
+---
+
+## IntValidator
+
+https://olivervea.github.io/Olve.Utilities/api/Olve.Validation.Validators.IntValidator.html
+
+Inherits: `BaseNumericStructValidator<int, IntValidator>`. Namespace: `Olve.Validation.Validators`.
+
+Validates `int` values. Inherits all numeric rules from BaseNumericStructValidator (`MustBeGreaterThan`, `MustBeLessThan`, `MustBeBetween`, `MustBePositive`, `MustBeNegative`, `MustBeZero`, etc.) and struct rules from BaseStructValidator (`CannotBeDefault`, `MustBeDefault`).
+
+Public members:
+
+```csharp
+public IntValidator MustBeEven();
+public IntValidator MustBeOdd();
+```
+
+- `MustBeEven` -- fails when value is not even.
+- `MustBeOdd` -- fails when value is not odd.
+
+---
+
+## DecimalValidator\<T\>
+
+https://olivervea.github.io/Olve.Utilities/api/Olve.Validation.Validators.DecimalValidator-1.html
+
+Inherits: `BaseNumericStructValidator<TValue, DecimalValidator<TValue>>`. Namespace: `Olve.Validation.Validators`.
+
+Constraints: `TValue : struct, INumber<TValue>`.
+
+Generic numeric validator for any `INumber<T>` type (`double`, `decimal`, `float`, etc.). Has no additional members beyond those inherited from BaseNumericStructValidator and BaseStructValidator.
+
+Usage:
+
+```csharp
+var result = new DecimalValidator<double>()
+    .MustBeBetween(0.0, 1.0)
+    .Validate(0.5);
+```
+
+---
+
+## EnumerableValidator\<T\>
+
+https://olivervea.github.io/Olve.Utilities/api/Olve.Validation.Validators.EnumerableValidator-1.html
+
+Inherits: `BaseEnumerableValidator<T, IEnumerable<T>, EnumerableValidator<T>>`. Namespace: `Olve.Validation.Validators`.
+
+Validates `IEnumerable<T>?` values. Has no additional members beyond those inherited from BaseEnumerableValidator and BaseObjectValidator.
+
+Inherited public rules: `CannotBeNull()`, `CannotBeEmpty()`, `CannotContainDuplicates()`, `MustHaveCountGreaterThan()`, `MustBeOneOf()`, `CannotBeOneOf()`, `WithProblem()`, `WithMessage()`, `Validate()`.
+
+---
+
+## ListValidator\<T\>
+
+https://olivervea.github.io/Olve.Utilities/api/Olve.Validation.Validators.ListValidator-1.html
+
+Inherits: `BaseEnumerableValidator<T, IList<T>, ListValidator<T>>`. Namespace: `Olve.Validation.Validators`.
+
+Validates `IList<T>?` values. Optimized version of EnumerableValidator that overrides `GetCount` to use `IList<T>.Count` instead of LINQ `Count()`.
+
+Overridden members:
+
+```csharp
+protected override int GetCount(IList<T> enumerable);  // uses .Count property
+```
+
+Inherited public rules: same as EnumerableValidator.

--- a/olve-packages/skills/olve-validation/references/Interfaces.md
+++ b/olve-packages/skills/olve-validation/references/Interfaces.md
@@ -1,0 +1,31 @@
+# Interfaces
+
+## IValidator\<T\>
+
+https://olivervea.github.io/Olve.Utilities/api/Olve.Validation.IValidator-1.html
+
+Interface for any validator that returns `Result`. Namespace: `Olve.Validation`.
+
+```csharp
+public interface IValidator<in TValue>
+{
+    Result Validate(TValue value);
+}
+```
+
+All concrete validators implement this interface. It allows validators to be passed as dependencies and used polymorphically.
+
+## IValidatable
+
+https://olivervea.github.io/Olve.Utilities/api/Olve.Validation.IValidatable.html
+
+Interface for objects that can validate their own state. Namespace: `Olve.Validation`.
+
+```csharp
+public interface IValidatable
+{
+    Result Validate();
+}
+```
+
+Implement this on domain objects or DTOs that need self-validation. The parameterless `Validate()` inspects the object's own fields and returns a `Result` indicating success or containing all problems found.

--- a/olve-packages/skills/olve-validation/references/README.md
+++ b/olve-packages/skills/olve-validation/references/README.md
@@ -1,0 +1,36 @@
+# Olve.Validation
+
+Source: https://olivervea.github.io/Olve.Utilities/api/Olve.Validation.html
+
+Fluent validation helpers built on top of Olve.Results. Validators accumulate rules via a fluent API and return a `Result` containing all problems found.
+
+## Key Types
+
+- **IValidator\<T\>** -- Interface for any validator that returns `Result`.
+- **IValidatable** -- Interface for objects that can validate their own state.
+- **BaseValidator\<TValue, TValidator\>** -- Abstract base with rule accumulation, `Validate()`, `WithProblem()`, `WithMessage()`.
+- **BaseStructValidator** -- Adds `CannotBeDefault()` / `MustBeDefault()` for struct types.
+- **BaseObjectValidator** -- Adds `CannotBeNull()`, `MustBeOneOf()`, `CannotBeOneOf()` for reference types.
+- **BaseNumericStructValidator** -- Numeric range rules (`MustBeGreaterThan`, `MustBeBetween`, `MustBePositive`, etc.).
+- **BaseEnumerableValidator** -- Collection rules (`CannotBeEmpty`, `CannotContainDuplicates`, `MustHaveCountGreaterThan`).
+- **StringValidator** -- String validation: null checks, length constraints.
+- **IntValidator** -- Integer validation: numeric range, even/odd.
+- **DecimalValidator\<T\>** -- Generic numeric validation for any `INumber<T>` type.
+- **EnumerableValidator\<T\>** -- Collection validation for `IEnumerable<T>`.
+- **ListValidator\<T\>** -- Optimized collection validation for `IList<T>`.
+
+## Primary Usage Pattern
+
+1. Instantiate a concrete validator (e.g., `new StringValidator()`).
+2. Chain rules fluently (e.g., `.CannotBeNullOrWhiteSpace().MustHaveMinLength(3)`).
+3. Optionally override error messages with `.WithMessage()` or `.WithProblem()` after each rule.
+4. Call `.Validate(value)` to get a `Result`.
+5. Check the result with `TryPickProblems` as you would with any `Result`.
+
+## Design Philosophy
+
+Validators are composable, stateless rule builders. Each rule is a predicate paired with a problem factory. Rules are evaluated independently -- all failing rules contribute problems to the result rather than short-circuiting. This makes validation results comprehensive.
+
+The inheritance hierarchy (BaseValidator -> BaseStructValidator/BaseObjectValidator -> concrete) provides reusable rule sets at each level while keeping the fluent API strongly typed via CRTP (curiously recurring template pattern).
+
+Validators return `Result` from Olve.Results, so they integrate directly with the rest of the error-handling ecosystem (Chain, Concat, Prepend, etc.).


### PR DESCRIPTION
## Summary
- Adds `olve-packages/` Claude Code plugin with API reference skills for all 9 non-deprecated packages
- Adds marketplace manifest (`.claude-plugin/marketplace.json`) for easy installation in downstream repos
- Documents installation in README

## Packages covered
- olve-results (7 reference files)
- olve-results-tunit
- olve-paths (6 reference files)
- olve-paths-glob
- olve-validation (4 reference files)
- olve-utilities (8 reference files)
- olve-minimal-api (5 reference files)
- olve-openraster (3 reference files)
- olve-tinyexr (3 reference files)

## Installation (downstream)
```bash
claude plugin marketplace add OliverVea/Olve.Utilities --sparse .claude-plugin olve-packages
claude plugin install olve-packages --scope project
```

## Test plan
- [x] `claude plugin validate ./olve-packages` passes
- [x] `claude --plugin-dir ./olve-packages` loads all 10 skills
- [x] Skills load from a downstream repo via `--plugin-dir`
- [ ] Test marketplace install end-to-end after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)