### PR TITLE
feat: enforce result observation with MustBeUsedWhenReturned analyzer

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*.cs]
+# ORES001 (Olve.Results MustBeUsedWhenReturned): result types must be observed.
+# Enforced as a build error in production via TreatWarningsAsErrors.
+dotnet_diagnostic.ORES001.severity = warning
+
+# Tests frequently exercise results for their side effects without observing the
+# return value. Keep ORES001 visible there as a non-breaking suggestion rather than
+# failing the test build; clean these up incrementally.
+[tests/**.cs]
+dotnet_diagnostic.ORES001.severity = suggestion

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,7 @@
 <Project>
     <PropertyGroup>
-        <TargetFramework>net10.0</TargetFramework>
+        <!-- The analyzer project pins its own TargetFramework (netstandard2.0); don't force net10.0 on it. -->
+        <TargetFramework Condition="'$(MSBuildProjectName)' != 'Olve.Results.Analyzers'">net10.0</TargetFramework>
         <LangVersion>latest</LangVersion>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <Nullable>enable</Nullable>
@@ -8,4 +9,17 @@
         <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
         <RuntimeIdentifiers>win-x64;linux-x64</RuntimeIdentifiers>
     </PropertyGroup>
+
+    <!--
+        Attach the local Olve.Results analyzer (MustBeUsedWhenReturned / ORES001) to every project
+        in the repo so result observation is enforced repo-wide. The analyzer no-ops in projects that
+        don't reference Olve.Results (the marker attribute symbol won't resolve). External consumers
+        receive the same analyzer via the Olve.Results NuGet package (packed under analyzers/dotnet/cs).
+    -->
+    <ItemGroup Condition="'$(MSBuildProjectName)' != 'Olve.Results.Analyzers'">
+        <ProjectReference Include="$(MSBuildThisFileDirectory)src/Olve.Results.Analyzers/Olve.Results.Analyzers.csproj"
+                          PrivateAssets="all"
+                          ReferenceOutputAssembly="false"
+                          OutputItemType="Analyzer" />
+    </ItemGroup>
 </Project>

--- a/Olve.Utilities.slnx
+++ b/Olve.Utilities.slnx
@@ -33,6 +33,7 @@
     <Project Path="src/Olve.Operations/Olve.Operations.csproj" />
     <Project Path="src/Olve.Paths.Glob/Olve.Paths.Glob.csproj" />
     <Project Path="src/Olve.Paths/Olve.Paths.csproj" />
+    <Project Path="src/Olve.Results.Analyzers/Olve.Results.Analyzers.csproj" />
     <Project Path="src/Olve.Results.TUnit/Olve.Results.TUnit.csproj" />
     <Project Path="src/Olve.Results/Olve.Results.csproj" />
     <Project Path="src/Olve.Utilities/Olve.Utilities.csproj" />

--- a/src/Olve.OpenRaster/Parsing/LayerImageReader.cs
+++ b/src/Olve.OpenRaster/Parsing/LayerImageReader.cs
@@ -17,7 +17,7 @@ internal static class LayerImageReader
 
         if (layerParser.ParseLayer(stream).TryPickProblems(out var problems, out var image))
         {
-            problems.Prepend(new ResultProblem("could not read image file '{0}'", imageSource));
+            problems = problems.Prepend(new ResultProblem("could not read image file '{0}'", imageSource));
             return problems;
         }
 

--- a/src/Olve.OpenRaster/Parsing/StackElementParser.cs
+++ b/src/Olve.OpenRaster/Parsing/StackElementParser.cs
@@ -11,7 +11,7 @@ internal static class StackElementParser
 
         if (results.TryPickProblems(out var problems))
         {
-            problems.Prepend(new ResultProblem("could not parse stack elements"));
+            problems = problems.Prepend(new ResultProblem("could not parse stack elements"));
             return problems;
         }
 

--- a/src/Olve.Results.Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/Olve.Results.Analyzers/AnalyzerReleases.Shipped.md
@@ -1,0 +1,2 @@
+; Shipped analyzer releases
+; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md

--- a/src/Olve.Results.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Olve.Results.Analyzers/AnalyzerReleases.Unshipped.md
@@ -1,0 +1,8 @@
+; Unshipped analyzer release
+; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+ORES001 | Usage    | Warning  | Return value of a type marked [MustBeUsedWhenReturned] must be observed

--- a/src/Olve.Results.Analyzers/MustBeUsedWhenReturnedAnalyzer.cs
+++ b/src/Olve.Results.Analyzers/MustBeUsedWhenReturnedAnalyzer.cs
@@ -1,0 +1,119 @@
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Olve.Results.Analyzers;
+
+/// <summary>
+///     Reports invocations whose result is a type marked with
+///     <c>Olve.Results.MustBeUsedWhenReturnedAttribute</c> but is not observed (the call is used as a
+///     statement). Task/ValueTask wrappers are unwrapped, so both <c>result;</c> and
+///     <c>await resultAsync;</c> are covered. Discards (<c>_ = ...</c>) and methods that consume the
+///     value (e.g. <c>DiscardResult()</c>) are not reported.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class MustBeUsedWhenReturnedAnalyzer : DiagnosticAnalyzer
+{
+    /// <summary>The diagnostic id reported by this analyzer.</summary>
+    public const string DiagnosticId = "ORES001";
+
+    private const string MarkerAttributeMetadataName = "Olve.Results.MustBeUsedWhenReturnedAttribute";
+
+    private static readonly DiagnosticDescriptor Rule = new(
+        id: DiagnosticId,
+        title: "Return value must be observed",
+        messageFormat: "The result of type '{0}' is marked [MustBeUsedWhenReturned] and must be observed",
+        category: "Usage",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "Values of types marked with [MustBeUsedWhenReturned] must be observed. " +
+                     "Use a discard ('_ = expression;') or 'DiscardResult()' to ignore one intentionally.");
+
+    /// <inheritdoc />
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
+
+    /// <inheritdoc />
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterCompilationStartAction(OnCompilationStart);
+    }
+
+    private static void OnCompilationStart(CompilationStartAnalysisContext context)
+    {
+        var marker = context.Compilation.GetTypeByMetadataName(MarkerAttributeMetadataName);
+        if (marker is null)
+        {
+            // The marker attribute (and therefore Olve.Results) is not referenced. Nothing to enforce.
+            return;
+        }
+
+        var taskOfT = context.Compilation.GetTypeByMetadataName("System.Threading.Tasks.Task`1");
+        var valueTaskOfT = context.Compilation.GetTypeByMetadataName("System.Threading.Tasks.ValueTask`1");
+
+        context.RegisterOperationAction(
+            ctx => Analyze(ctx, marker, taskOfT, valueTaskOfT),
+            OperationKind.ExpressionStatement);
+    }
+
+    private static void Analyze(
+        OperationAnalysisContext context,
+        INamedTypeSymbol marker,
+        INamedTypeSymbol? taskOfT,
+        INamedTypeSymbol? valueTaskOfT)
+    {
+        var statement = (IExpressionStatementOperation)context.Operation;
+
+        // Only a bare statement discards the value. 'var x = Foo();' and '_ = Foo();' wrap the
+        // invocation in a declaration/assignment, so they are not ExpressionStatement -> Invocation.
+        switch (statement.Operation)
+        {
+            case IInvocationOperation invocation:
+                var returnType = Unwrap(invocation.TargetMethod.ReturnType, taskOfT, valueTaskOfT);
+                if (IsMarked(returnType, marker))
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(Rule, invocation.Syntax.GetLocation(), returnType.Name));
+                }
+
+                break;
+
+            case IAwaitOperation { Type: { } awaitedType } await when IsMarked(awaitedType, marker):
+                context.ReportDiagnostic(Diagnostic.Create(Rule, await.Syntax.GetLocation(), awaitedType.Name));
+                break;
+        }
+    }
+
+    private static ITypeSymbol Unwrap(ITypeSymbol type, INamedTypeSymbol? taskOfT, INamedTypeSymbol? valueTaskOfT)
+    {
+        if (type is INamedTypeSymbol { IsGenericType: true } named)
+        {
+            var definition = named.OriginalDefinition;
+            if ((taskOfT is not null && SymbolEqualityComparer.Default.Equals(definition, taskOfT)) ||
+                (valueTaskOfT is not null && SymbolEqualityComparer.Default.Equals(definition, valueTaskOfT)))
+            {
+                return named.TypeArguments[0];
+            }
+        }
+
+        return type;
+    }
+
+    private static bool IsMarked(ITypeSymbol? type, INamedTypeSymbol marker)
+    {
+        for (var current = type; current is not null; current = current.BaseType)
+        {
+            if (HasMarker(current, marker) || HasMarker(current.OriginalDefinition, marker))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool HasMarker(ISymbol symbol, INamedTypeSymbol marker) =>
+        symbol.GetAttributes().Any(attribute => SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, marker));
+}

--- a/src/Olve.Results.Analyzers/Olve.Results.Analyzers.csproj
+++ b/src/Olve.Results.Analyzers/Olve.Results.Analyzers.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <!--
+        Roslyn analyzers must target netstandard2.0 and load inside the compiler host, so this is a
+        separate assembly from the net10.0 Olve.Results runtime. Its DLL is packed into the
+        Olve.Results NuGet package (see Olve.Results.csproj) so external consumers get it automatically,
+        and it is attached to repo projects via Directory.Build.props.
+    -->
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <RuntimeIdentifiers></RuntimeIdentifiers>
+        <ImplicitUsings>disable</ImplicitUsings>
+        <IsPackable>false</IsPackable>
+        <IncludeBuildOutput>false</IncludeBuildOutput>
+        <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <AdditionalFiles Include="AnalyzerReleases.Shipped.md" />
+        <AdditionalFiles Include="AnalyzerReleases.Unshipped.md" />
+    </ItemGroup>
+
+</Project>

--- a/src/Olve.Results/DeletionResult.cs
+++ b/src/Olve.Results/DeletionResult.cs
@@ -5,6 +5,7 @@ namespace Olve.Results;
 /// <summary>
 ///     Represents the result of a deletion operation, which can succeed, fail due to not being found, or fail due to an error.
 /// </summary>
+[MustBeUsedWhenReturned]
 public readonly struct DeletionResult
 {
     private DeletionResult(bool found, ResultProblemCollection? problems)

--- a/src/Olve.Results/DeletionResultExtensions.cs
+++ b/src/Olve.Results/DeletionResultExtensions.cs
@@ -6,6 +6,13 @@ namespace Olve.Results;
 public static class DeletionResultExtensions
 {
     /// <summary>
+    ///     Explicitly discards a <see cref="DeletionResult"/>, signalling that its outcome is
+    ///     intentionally not observed, e.g. <c>(await DeleteUser(id)).DiscardResult();</c>.
+    /// </summary>
+    /// <param name="result">The deletion result to discard.</param>
+    public static void DiscardResult(this DeletionResult result) => _ = result;
+
+    /// <summary>
     ///     Exhaustively matches over the three states of a <see cref="DeletionResult"/>.
     /// </summary>
     /// <param name="result">The deletion result to match.</param>

--- a/src/Olve.Results/MustBeUsedWhenReturnedAttribute.cs
+++ b/src/Olve.Results/MustBeUsedWhenReturnedAttribute.cs
@@ -1,0 +1,19 @@
+namespace Olve.Results;
+
+/// <summary>
+///     Marks a type whose values must always be observed when returned from a method.
+///     The Olve.Results analyzer (<c>ORES001</c>) reports a diagnostic when a method that returns an
+///     annotated type (directly or wrapped in <see cref="System.Threading.Tasks.Task{TResult}"/> /
+///     <see cref="System.Threading.Tasks.ValueTask{TResult}"/>) is invoked as a statement without
+///     observing the result.
+/// </summary>
+/// <remarks>
+///     Applied to <see cref="Result"/>, <see cref="Result{T}"/> and <see cref="DeletionResult"/>.
+///     Dependent projects can apply it to their own result-like types. To intentionally ignore a
+///     result, use a discard (<c>_ = expression;</c>) or call <c>DiscardResult()</c>.
+/// </remarks>
+[AttributeUsage(
+    AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Enum | AttributeTargets.Interface,
+    Inherited = false,
+    AllowMultiple = false)]
+public sealed class MustBeUsedWhenReturnedAttribute : Attribute;

--- a/src/Olve.Results/Olve.Results.csproj
+++ b/src/Olve.Results/Olve.Results.csproj
@@ -24,4 +24,28 @@
       <ProjectReference Include="..\Olve.Paths\Olve.Paths.csproj" />
     </ItemGroup>
 
+    <!--
+        Pack the Olve.Results analyzer DLL into this package so consumers automatically enforce
+        [MustBeUsedWhenReturned] (ORES001). The analyzer is attached to this project for its own
+        build via Directory.Build.props.
+    -->
+    <PropertyGroup>
+        <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_PackOlveResultsAnalyzer</TargetsForTfmSpecificContentInPackage>
+    </PropertyGroup>
+
+    <Target Name="_PackOlveResultsAnalyzer">
+        <!-- RemoveProperties strips the ambient TargetFramework=net10.0 so the netstandard2.0 analyzer builds correctly. -->
+        <MSBuild Projects="..\Olve.Results.Analyzers\Olve.Results.Analyzers.csproj"
+                 Targets="Build"
+                 Properties="Configuration=$(Configuration)"
+                 RemoveProperties="TargetFramework">
+            <Output TaskParameter="TargetOutputs" ItemName="_OlveResultsAnalyzerOutput" />
+        </MSBuild>
+        <ItemGroup>
+            <TfmSpecificPackageFile Include="@(_OlveResultsAnalyzerOutput)"
+                                    Condition="'%(Extension)' == '.dll'"
+                                    PackagePath="analyzers/dotnet/cs" />
+        </ItemGroup>
+    </Target>
+
 </Project>

--- a/src/Olve.Results/Olve.Results.csproj
+++ b/src/Olve.Results/Olve.Results.csproj
@@ -34,11 +34,17 @@
     </PropertyGroup>
 
     <Target Name="_PackOlveResultsAnalyzer">
-        <!-- RemoveProperties strips the ambient TargetFramework=net10.0 so the netstandard2.0 analyzer builds correctly. -->
+        <!--
+            RemoveProperties strips:
+            - TargetFramework: the ambient net10.0 must not leak into the netstandard2.0 analyzer build (NETSDK1005).
+            - NoBuild: `dotnet pack` with the no-build flag sets NoBuild=true globally; without removing it the
+              nested Build target errors with NETSDK1085. The analyzer is already built by the prior build step,
+              so this nested call is an incremental no-op that just surfaces TargetOutputs.
+        -->
         <MSBuild Projects="..\Olve.Results.Analyzers\Olve.Results.Analyzers.csproj"
                  Targets="Build"
                  Properties="Configuration=$(Configuration)"
-                 RemoveProperties="TargetFramework">
+                 RemoveProperties="TargetFramework;NoBuild">
             <Output TaskParameter="TargetOutputs" ItemName="_OlveResultsAnalyzerOutput" />
         </MSBuild>
         <ItemGroup>

--- a/src/Olve.Results/Result.Concat.cs
+++ b/src/Olve.Results/Result.Concat.cs
@@ -21,9 +21,9 @@ public readonly partial struct Result
 
         var problems = new ResultProblemCollection();
         if (a.TryPickProblems(out var p1))
-            problems.Append(p1);
+            problems = problems.Append(p1);
         if (b.TryPickProblems(out var p2))
-            problems.Append(p2);
+            problems = problems.Append(p2);
 
         return problems;
     }
@@ -52,11 +52,11 @@ public readonly partial struct Result
 
         var problems = new ResultProblemCollection();
         if (a.TryPickProblems(out var p1))
-            problems.Append(p1);
+            problems = problems.Append(p1);
         if (b.TryPickProblems(out var p2))
-            problems.Append(p2);
+            problems = problems.Append(p2);
         if (c.TryPickProblems(out var p3))
-            problems.Append(p3);
+            problems = problems.Append(p3);
 
         return problems;
     }
@@ -88,13 +88,13 @@ public readonly partial struct Result
 
         var problems = new ResultProblemCollection();
         if (a.TryPickProblems(out var p1))
-            problems.Append(p1);
+            problems = problems.Append(p1);
         if (b.TryPickProblems(out var p2))
-            problems.Append(p2);
+            problems = problems.Append(p2);
         if (c.TryPickProblems(out var p3))
-            problems.Append(p3);
+            problems = problems.Append(p3);
         if (d.TryPickProblems(out var p4))
-            problems.Append(p4);
+            problems = problems.Append(p4);
 
         return problems;
     }
@@ -129,15 +129,15 @@ public readonly partial struct Result
 
         var problems = new ResultProblemCollection();
         if (a.TryPickProblems(out var p1))
-            problems.Append(p1);
+            problems = problems.Append(p1);
         if (b.TryPickProblems(out var p2))
-            problems.Append(p2);
+            problems = problems.Append(p2);
         if (c.TryPickProblems(out var p3))
-            problems.Append(p3);
+            problems = problems.Append(p3);
         if (d.TryPickProblems(out var p4))
-            problems.Append(p4);
+            problems = problems.Append(p4);
         if (e.TryPickProblems(out var p5))
-            problems.Append(p5);
+            problems = problems.Append(p5);
 
         return problems;
     }
@@ -175,17 +175,17 @@ public readonly partial struct Result
 
         var problems = new ResultProblemCollection();
         if (a.TryPickProblems(out var p1))
-            problems.Append(p1);
+            problems = problems.Append(p1);
         if (b.TryPickProblems(out var p2))
-            problems.Append(p2);
+            problems = problems.Append(p2);
         if (c.TryPickProblems(out var p3))
-            problems.Append(p3);
+            problems = problems.Append(p3);
         if (d.TryPickProblems(out var p4))
-            problems.Append(p4);
+            problems = problems.Append(p4);
         if (e.TryPickProblems(out var p5))
-            problems.Append(p5);
+            problems = problems.Append(p5);
         if (f.TryPickProblems(out var p6))
-            problems.Append(p6);
+            problems = problems.Append(p6);
 
         return problems;
     }

--- a/src/Olve.Results/Result.cs
+++ b/src/Olve.Results/Result.cs
@@ -6,6 +6,7 @@ namespace Olve.Results;
 /// <summary>
 ///     Represents a result of an operation without a value, indicating success or failure.
 /// </summary>
+[MustBeUsedWhenReturned]
 public readonly partial struct Result : IResultType
 {
     private Result(ResultProblemCollection? problems)

--- a/src/Olve.Results/ResultExtensions.cs
+++ b/src/Olve.Results/ResultExtensions.cs
@@ -6,6 +6,23 @@ namespace Olve.Results;
 public static class ResultExtensions
 {
     /// <summary>
+    ///     Explicitly discards a <see cref="Result"/>, signalling that its success or failure is
+    ///     intentionally not observed. Use this to satisfy the unobserved-result analyzer (EPC13)
+    ///     when ignoring a result is deliberate, e.g. <c>(await CreateUser(request)).DiscardResult();</c>.
+    /// </summary>
+    /// <param name="result">The result to discard.</param>
+    public static void DiscardResult(this Result result) => _ = result;
+
+    /// <summary>
+    ///     Explicitly discards a <see cref="Result{T}"/>, signalling that its success or failure is
+    ///     intentionally not observed. Use this to satisfy the unobserved-result analyzer (EPC13)
+    ///     when ignoring a result is deliberate, e.g. <c>(await CreateUser(request)).DiscardResult();</c>.
+    /// </summary>
+    /// <param name="result">The result to discard.</param>
+    /// <typeparam name="T">The type of the discarded value.</typeparam>
+    public static void DiscardResult<T>(this Result<T> result) => _ = result;
+
+    /// <summary>
     ///     Discards the value of a <see cref="Result{T}"/>, keeping only the success/failure status.
     /// </summary>
     /// <param name="result">The result to convert.</param>

--- a/src/Olve.Results/Result`1.cs
+++ b/src/Olve.Results/Result`1.cs
@@ -6,6 +6,7 @@ namespace Olve.Results;
 ///     Represents a result of an operation with a value, indicating success or failure.
 /// </summary>
 /// <typeparam name="T">The type of the result value.</typeparam>
+[MustBeUsedWhenReturned]
 public readonly struct Result<T> : IResultType
 {
     internal Result(T? result, ResultProblemCollection? problems)

--- a/tests/Olve.Results.Tests/ResultTests.cs
+++ b/tests/Olve.Results.Tests/ResultTests.cs
@@ -135,6 +135,38 @@ public class ResultTests
     }
 
     [Test]
+    public async Task Concat_WhenBothFail_AggregatesAllProblems()
+    {
+        // Arrange
+        Result<int> a = new ResultProblem("problem A");
+        Result<int> b = new ResultProblem("problem B");
+
+        // Act
+        var result = Result.Concat(a, b);
+
+        // Assert
+        await Assert.That(result.Failed).IsTrue();
+        await Assert.That(result.TryPickProblems(out var problems)).IsTrue();
+        await Assert.That(problems!.Count()).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Concat_Func_WhenBothFail_AggregatesAllProblems()
+    {
+        // Arrange
+        Func<Result<int>> a = () => new ResultProblem("problem A");
+        Func<Result<int>> b = () => new ResultProblem("problem B");
+
+        // Act
+        var result = Result.Concat(a, b);
+
+        // Assert
+        await Assert.That(result.Failed).IsTrue();
+        await Assert.That(result.TryPickProblems(out var problems)).IsTrue();
+        await Assert.That(problems!.Count()).IsEqualTo(2);
+    }
+
+    [Test]
     [Arguments(false, false, false, false)]
     [Arguments(true, false, true, false)]
     [Arguments(false, true, false, false)]


### PR DESCRIPTION
Enforces "result types must be observed" for `Olve.Results` (`Result`, `Result<T>`, `DeletionResult`) via a custom Roslyn analyzer (`ORES001`) that also ships to package consumers.

## Changes

**fix — aggregate all problems** (`813348c`)
`Result.Concat` (all 6 overloads, direct + `Func`) and both OpenRaster parsers discarded the return of the *immutable* `ResultProblemCollection.Append`/`Prepend`, silently dropping all problems on failure paths.

**feat — MustBeUsedWhenReturned analyzer** (`74ffc64`)
- `[MustBeUsedWhenReturned]` attribute applied to `Result`/`Result<T>`/`DeletionResult`
- Analyzer project `src/Olve.Results.Analyzers/` — diagnostic `ORES001`, attribute-based, unwraps `Task`/`ValueTask`
- Packed into `Olve.Results.nupkg` at `analyzers/dotnet/cs/`, attached repo-wide via `Directory.Build.props`
- `DiscardResult()` escape hatch on all three types
- `.editorconfig`: ORES001 = error in `src/` (via TWAE), suggestion in `tests/`

The analyzer mirrors ErrorProne's detection structure (flag at `ExpressionStatement → Invocation/Await`, giving `_ =` / observed escape hatches for free) but is attribute-based and intentionally **strict**: a fluent extension returning a marked type, called as a bare statement, is flagged (suppress with `_ =` or `.DiscardResult()`).

## Notes for next release
`ORES001` is currently in `AnalyzerReleases.Unshipped.md` — move it to `.Shipped.md` when cutting the next `Olve.Results` release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)